### PR TITLE
Reworked stubs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+-e git+https://github.com/cobusc/apitools@master#egg=apitools
 swagger-parser
 click
 nose

--- a/swagger_django_generator/templates/stubs.py
+++ b/swagger_django_generator/templates/stubs.py
@@ -4,21 +4,61 @@ updated with implementation specific code.
 Use a tool like meld to pull in new definitions as opposed to overwriting
 this file.
 """
+import json
+from apitools.datagenerator import DataGenerator
+
+import {{ module }}.schemas as schemas
+
+
+class AbstractStubClass(object):
+    """
+    Implementations need to be derived from this class.
+    """
 {% for class_name, verbs in classes|dictsort(true) %}
     {% for verb, info in verbs|dictsort(true) %}
 
-
-def {{ info.operation }}(request, {% if info.body %}body, {% endif %}{% for ra in info.required_args %}{{ ra.name }}, {% endfor %}{% for oa in info.optional_args %}{{ oa.name }}=None, {% endfor %}*args, **kwargs):
-    """
-    :param request: An HttpRequest
-    {% for ra in info.required_args %}
-    :param {{ ra.name }}: {{ ra.type }} {{ ra.description }}
-    {% endfor %}
-    {% for ra in info.option_args %}
-    :param {{ ra.name }} (optional): {{ ra.type }} {{ ra.description }}
-    {% endfor %}
-    """
-    # TODO: Implement me
-    return {}
+    @staticmethod
+    def {{ info.operation }}(request, {% if info.body %}body, {% endif %}{% for ra in info.required_args %}{{ ra.name }}, {% endfor %}{% for oa in info.optional_args %}{{ oa.name }}=None, {% endfor %}*args, **kwargs):
+        """
+        :param request: An HttpRequest
+        {% for ra in info.required_args %}
+        :param {{ ra.name }}: {{ ra.type }} {{ ra.description }}
+        {% endfor %}
+        {% for ra in info.option_args %}
+        :param {{ ra.name }} (optional): {{ ra.type }} {{ ra.description }}
+        {% endfor %}
+        """
+        raise NotImplementedError()
    {% endfor %}
+{% endfor %}
+
+
+class MockedStubClass(AbstractStubClass):
+    """
+    Provides a mocked implementation of the AbstractStubClass.
+    """
+    GENERATOR = DataGenerator()
+{% for class_name, verbs in classes|dictsort(true) %}
+    {% for verb, info in verbs|dictsort(true) %}
+
+    @staticmethod
+    def {{ info.operation }}(request, {% if info.body %}body, {% endif %}{% for ra in info.required_args %}{{ ra.name }}, {% endfor %}{% for oa in info.optional_args %}{{ oa.name }}=None, {% endfor %}*args, **kwargs):
+        """
+        :param request: An HttpRequest
+        {% for ra in info.required_args %}
+        :param {{ ra.name }}: {{ ra.type }} {{ ra.description }}
+        {% endfor %}
+        {% for ra in info.option_args %}
+        :param {{ ra.name }} (optional): {{ ra.type }} {{ ra.description }}
+        {% endfor %}
+        """
+        response_schema = {{ info.response_schema }}
+        if "type" not in response_schema:
+            response_schema["type"] = "object"
+
+        if response_schema["type"] == "array" and "type" not in response_schema["items"]:
+            response_schema["items"]["type"] = "object"
+
+        return MockedStubClass.GENERATOR.random_value(response_schema)
+    {% endfor %}
 {% endfor %}

--- a/swagger_django_generator/templates/views.py
+++ b/swagger_django_generator/templates/views.py
@@ -2,6 +2,7 @@
 Do not modify this file. It is generated from the Swagger specification.
 
 """
+import importlib
 import logging
 import json
 import jsonschema
@@ -13,13 +14,13 @@ from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
 from django.views import View
 
-from {{ module }}.stubs import MockedStubClass as Stubs
 import {{ module }}.schemas as schemas
 import {{ module }}.utils as utils
 
-
+# Set up logging
 logging.basicConfig(level=logging.DEBUG)
 LOGGER = logging.getLogger(__name__)
+
 try:
     VALIDATE_RESPONSES = settings.SWAGGER_API_VALIDATE_RESPONSES
 except AttributeError:
@@ -27,6 +28,17 @@ except AttributeError:
 LOGGER.info("Swagger API response validation is {}".format(
     "on" if VALIDATE_RESPONSES else "off"
 ))
+
+# Set up the stub class. If it is not explicitly configured in the settings.py
+# file of the project, we default to a mocked class.
+try:
+    stub_class_path = settings.STUBS_CLASS
+except AttributeError:
+    stub_class_path = "{{ module }}.stubs.MockedStubClass"
+
+module_name, class_name = stub_class_path.rsplit(".", 1)
+Module = importlib.import_module(module_name)
+Stubs = getattr(Module, class_name)
 
 
 def maybe_validate_result(result, schema):

--- a/swagger_django_generator/templates/views.py
+++ b/swagger_django_generator/templates/views.py
@@ -13,7 +13,7 @@ from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
 from django.views import View
 
-import {{ module }}.stubs as stubs
+from {{ module }}.stubs import MockedStubClass as Stubs
 import {{ module }}.schemas as schemas
 import {{ module }}.utils as utils
 
@@ -68,7 +68,7 @@ class {{ class_name }}(View):
         {% if info.body %}
         body = utils.body_to_dict(request.body, self.{{ verb|upper}}_BODY_SCHEMA)
         {% endif %}
-        result = stubs.{{ info.operation }}(request, {% if info.body %}body, {% endif %}{% for ra in info.required_args %}{{ ra.name }}, {% endfor %}{% for oa in info.optional_args %}{{ oa.name }}=None, {% endfor %}*args, **kwargs)
+        result = Stubs.{{ info.operation }}(request, {% if info.body %}body, {% endif %}{% for ra in info.required_args %}{{ ra.name }}, {% endfor %}{% for oa in info.optional_args %}{{ oa.name }}=None, {% endfor %}*args, **kwargs)
         maybe_validate_result(result, self.{{ verb|upper }}_RESPONSE_SCHEMA)
 
         return JsonResponse(result, safe=False)
@@ -86,5 +86,9 @@ class __SWAGGER_SPEC__(View):
         # Mod spec to point to demo application
         spec["basePath"] = "/"
         spec["host"] = "localhost:8000"
+        # Add basic auth as a security definition
+        security_definitions = spec.get("securityDefinitions", {})
+        security_definitions["basic_auth"] = {"type": "basic"}
+        spec["securityDefinitions"] = security_definitions
         return JsonResponse(spec)
 


### PR DESCRIPTION
* Creation of an Abstract Base Class off which an actual implementation should be derived.
* Creation of a mocked implentation based on the ABC.
* The class to containing stubs now need to be specified in `settings.py`, e.g. `STUBS_CLASS = demo.mystubs.StubClass`