### PR TITLE
Improved validation for Django and aiohttp

### DIFF
--- a/demo/demo/views.py
+++ b/demo/demo/views.py
@@ -67,24 +67,30 @@ class Pet(View):
         if not body:
             return HttpResponseBadRequest("Body required")
 
-        result = Stubs.addPet(request, body, )
+        try:
 
-        if type(result) is tuple:
-            result, headers = result
-        else:
-            headers = {}
+            result = Stubs.addPet(request, body, )
 
-        # The result may contain fields with date or datetime values that will not
-        # pass JSON validation. We first create the response, and then maybe validate
-        # the response content against the schema.
-        response = JsonResponse(result, safe=False)
+            if type(result) is tuple:
+                result, headers = result
+            else:
+                headers = {}
 
-        maybe_validate_result(response.content, self.POST_RESPONSE_SCHEMA)
+            # The result may contain fields with date or datetime values that will not
+            # pass JSON validation. We first create the response, and then maybe validate
+            # the response content against the schema.
+            response = JsonResponse(result, safe=False)
 
-        for key, val in headers.items():
-            response[key] = val
+            maybe_validate_result(response.content, self.POST_RESPONSE_SCHEMA)
 
-        return response
+            for key, val in headers.items():
+                response[key] = val
+
+            return response
+        except ValidationError as ve:
+            return HttpResponseBadRequest("Parameter validation failed: {}".format(ve.message))
+        except ValueError as ve:
+            return HttpResponseBadRequest("Parameter validation failed: {}".format(ve))
 
     def put(self, request, *args, **kwargs):
         """
@@ -95,24 +101,30 @@ class Pet(View):
         if not body:
             return HttpResponseBadRequest("Body required")
 
-        result = Stubs.updatePet(request, body, )
+        try:
 
-        if type(result) is tuple:
-            result, headers = result
-        else:
-            headers = {}
+            result = Stubs.updatePet(request, body, )
 
-        # The result may contain fields with date or datetime values that will not
-        # pass JSON validation. We first create the response, and then maybe validate
-        # the response content against the schema.
-        response = JsonResponse(result, safe=False)
+            if type(result) is tuple:
+                result, headers = result
+            else:
+                headers = {}
 
-        maybe_validate_result(response.content, self.PUT_RESPONSE_SCHEMA)
+            # The result may contain fields with date or datetime values that will not
+            # pass JSON validation. We first create the response, and then maybe validate
+            # the response content against the schema.
+            response = JsonResponse(result, safe=False)
 
-        for key, val in headers.items():
-            response[key] = val
+            maybe_validate_result(response.content, self.PUT_RESPONSE_SCHEMA)
 
-        return response
+            for key, val in headers.items():
+                response[key] = val
+
+            return response
+        except ValidationError as ve:
+            return HttpResponseBadRequest("Parameter validation failed: {}".format(ve.message))
+        except ValueError as ve:
+            return HttpResponseBadRequest("Parameter validation failed: {}".format(ve))
 
 
 @method_decorator(csrf_exempt, name="dispatch")
@@ -212,26 +224,35 @@ class PetFindByStatus(View):
         :param self: A PetFindByStatus instance
         :param request: An HttpRequest
         """
-        # status (optional): array Status values that need to be considered for filter
-        status = request.GET.getlist("status", None)
-        result = Stubs.findPetsByStatus(request, status, )
+        try:
 
-        if type(result) is tuple:
-            result, headers = result
-        else:
-            headers = {}
+            # status (optional): array Status values that need to be considered for filter
+            status = request.GET.getlist("status", None)
+            if status is not None:
+                schema = {'type': 'array', 'items': {'type': 'string', 'enum': ['available', 'pending', 'sold']}, 'default': 'available'}
+                utils.validate(status, schema)
+            result = Stubs.findPetsByStatus(request, status, )
 
-        # The result may contain fields with date or datetime values that will not
-        # pass JSON validation. We first create the response, and then maybe validate
-        # the response content against the schema.
-        response = JsonResponse(result, safe=False)
+            if type(result) is tuple:
+                result, headers = result
+            else:
+                headers = {}
 
-        maybe_validate_result(response.content, self.GET_RESPONSE_SCHEMA)
+            # The result may contain fields with date or datetime values that will not
+            # pass JSON validation. We first create the response, and then maybe validate
+            # the response content against the schema.
+            response = JsonResponse(result, safe=False)
 
-        for key, val in headers.items():
-            response[key] = val
+            maybe_validate_result(response.content, self.GET_RESPONSE_SCHEMA)
 
-        return response
+            for key, val in headers.items():
+                response[key] = val
+
+            return response
+        except ValidationError as ve:
+            return HttpResponseBadRequest("Parameter validation failed: {}".format(ve.message))
+        except ValueError as ve:
+            return HttpResponseBadRequest("Parameter validation failed: {}".format(ve))
 
 
 @method_decorator(csrf_exempt, name="dispatch")
@@ -331,26 +352,35 @@ class PetFindByTags(View):
         :param self: A PetFindByTags instance
         :param request: An HttpRequest
         """
-        # tags (optional): array Tags to filter by
-        tags = request.GET.getlist("tags", None)
-        result = Stubs.findPetsByTags(request, tags, )
+        try:
 
-        if type(result) is tuple:
-            result, headers = result
-        else:
-            headers = {}
+            # tags (optional): array Tags to filter by
+            tags = request.GET.getlist("tags", None)
+            if tags is not None:
+                schema = {'type': 'array', 'items': {'type': 'string'}}
+                utils.validate(tags, schema)
+            result = Stubs.findPetsByTags(request, tags, )
 
-        # The result may contain fields with date or datetime values that will not
-        # pass JSON validation. We first create the response, and then maybe validate
-        # the response content against the schema.
-        response = JsonResponse(result, safe=False)
+            if type(result) is tuple:
+                result, headers = result
+            else:
+                headers = {}
 
-        maybe_validate_result(response.content, self.GET_RESPONSE_SCHEMA)
+            # The result may contain fields with date or datetime values that will not
+            # pass JSON validation. We first create the response, and then maybe validate
+            # the response content against the schema.
+            response = JsonResponse(result, safe=False)
 
-        for key, val in headers.items():
-            response[key] = val
+            maybe_validate_result(response.content, self.GET_RESPONSE_SCHEMA)
 
-        return response
+            for key, val in headers.items():
+                response[key] = val
+
+            return response
+        except ValidationError as ve:
+            return HttpResponseBadRequest("Parameter validation failed: {}".format(ve.message))
+        except ValueError as ve:
+            return HttpResponseBadRequest("Parameter validation failed: {}".format(ve))
 
 
 @method_decorator(csrf_exempt, name="dispatch")
@@ -369,24 +399,30 @@ class PetPetId(View):
         :param request: An HttpRequest
         :param petId: integer Pet id to delete
         """
-        result = Stubs.deletePet(request, petId, )
+        try:
 
-        if type(result) is tuple:
-            result, headers = result
-        else:
-            headers = {}
+            result = Stubs.deletePet(request, petId, )
 
-        # The result may contain fields with date or datetime values that will not
-        # pass JSON validation. We first create the response, and then maybe validate
-        # the response content against the schema.
-        response = JsonResponse(result, safe=False)
+            if type(result) is tuple:
+                result, headers = result
+            else:
+                headers = {}
 
-        maybe_validate_result(response.content, self.DELETE_RESPONSE_SCHEMA)
+            # The result may contain fields with date or datetime values that will not
+            # pass JSON validation. We first create the response, and then maybe validate
+            # the response content against the schema.
+            response = JsonResponse(result, safe=False)
 
-        for key, val in headers.items():
-            response[key] = val
+            maybe_validate_result(response.content, self.DELETE_RESPONSE_SCHEMA)
 
-        return response
+            for key, val in headers.items():
+                response[key] = val
+
+            return response
+        except ValidationError as ve:
+            return HttpResponseBadRequest("Parameter validation failed: {}".format(ve.message))
+        except ValueError as ve:
+            return HttpResponseBadRequest("Parameter validation failed: {}".format(ve))
 
     def get(self, request, petId, *args, **kwargs):
         """
@@ -394,24 +430,30 @@ class PetPetId(View):
         :param request: An HttpRequest
         :param petId: integer ID of pet that needs to be fetched
         """
-        result = Stubs.getPetById(request, petId, )
+        try:
 
-        if type(result) is tuple:
-            result, headers = result
-        else:
-            headers = {}
+            result = Stubs.getPetById(request, petId, )
 
-        # The result may contain fields with date or datetime values that will not
-        # pass JSON validation. We first create the response, and then maybe validate
-        # the response content against the schema.
-        response = JsonResponse(result, safe=False)
+            if type(result) is tuple:
+                result, headers = result
+            else:
+                headers = {}
 
-        maybe_validate_result(response.content, self.GET_RESPONSE_SCHEMA)
+            # The result may contain fields with date or datetime values that will not
+            # pass JSON validation. We first create the response, and then maybe validate
+            # the response content against the schema.
+            response = JsonResponse(result, safe=False)
 
-        for key, val in headers.items():
-            response[key] = val
+            maybe_validate_result(response.content, self.GET_RESPONSE_SCHEMA)
 
-        return response
+            for key, val in headers.items():
+                response[key] = val
+
+            return response
+        except ValidationError as ve:
+            return HttpResponseBadRequest("Parameter validation failed: {}".format(ve.message))
+        except ValueError as ve:
+            return HttpResponseBadRequest("Parameter validation failed: {}".format(ve))
 
     def post(self, request, petId, *args, **kwargs):
         """
@@ -419,31 +461,37 @@ class PetPetId(View):
         :param request: An HttpRequest
         :param petId: string ID of pet that needs to be updated
         """
-        form_data = {}
-        name = request.POST.get("name", None)
-        form_data["name"] = name
+        try:
 
-        status = request.POST.get("status", None)
-        form_data["status"] = status
+            form_data = {}
+            name = request.POST.get("name", None)
+            form_data["name"] = name
 
-        result = Stubs.updatePetWithForm(request, form_data, petId, )
+            status = request.POST.get("status", None)
+            form_data["status"] = status
 
-        if type(result) is tuple:
-            result, headers = result
-        else:
-            headers = {}
+            result = Stubs.updatePetWithForm(request, form_data, petId, )
 
-        # The result may contain fields with date or datetime values that will not
-        # pass JSON validation. We first create the response, and then maybe validate
-        # the response content against the schema.
-        response = JsonResponse(result, safe=False)
+            if type(result) is tuple:
+                result, headers = result
+            else:
+                headers = {}
 
-        maybe_validate_result(response.content, self.POST_RESPONSE_SCHEMA)
+            # The result may contain fields with date or datetime values that will not
+            # pass JSON validation. We first create the response, and then maybe validate
+            # the response content against the schema.
+            response = JsonResponse(result, safe=False)
 
-        for key, val in headers.items():
-            response[key] = val
+            maybe_validate_result(response.content, self.POST_RESPONSE_SCHEMA)
 
-        return response
+            for key, val in headers.items():
+                response[key] = val
+
+            return response
+        except ValidationError as ve:
+            return HttpResponseBadRequest("Parameter validation failed: {}".format(ve.message))
+        except ValueError as ve:
+            return HttpResponseBadRequest("Parameter validation failed: {}".format(ve))
 
 
 @method_decorator(csrf_exempt, name="dispatch")
@@ -458,31 +506,37 @@ class PetPetIdUploadImage(View):
         :param request: An HttpRequest
         :param petId: integer ID of pet to update
         """
-        form_data = {}
-        additionalMetadata = request.POST.get("additionalMetadata", None)
-        form_data["additionalMetadata"] = additionalMetadata
+        try:
 
-        file = request.FILES.get("file", None)
-        form_data["file"] = file
+            form_data = {}
+            additionalMetadata = request.POST.get("additionalMetadata", None)
+            form_data["additionalMetadata"] = additionalMetadata
 
-        result = Stubs.uploadFile(request, form_data, petId, )
+            file = request.FILES.get("file", None)
+            form_data["file"] = file
 
-        if type(result) is tuple:
-            result, headers = result
-        else:
-            headers = {}
+            result = Stubs.uploadFile(request, form_data, petId, )
 
-        # The result may contain fields with date or datetime values that will not
-        # pass JSON validation. We first create the response, and then maybe validate
-        # the response content against the schema.
-        response = JsonResponse(result, safe=False)
+            if type(result) is tuple:
+                result, headers = result
+            else:
+                headers = {}
 
-        maybe_validate_result(response.content, self.POST_RESPONSE_SCHEMA)
+            # The result may contain fields with date or datetime values that will not
+            # pass JSON validation. We first create the response, and then maybe validate
+            # the response content against the schema.
+            response = JsonResponse(result, safe=False)
 
-        for key, val in headers.items():
-            response[key] = val
+            maybe_validate_result(response.content, self.POST_RESPONSE_SCHEMA)
 
-        return response
+            for key, val in headers.items():
+                response[key] = val
+
+            return response
+        except ValidationError as ve:
+            return HttpResponseBadRequest("Parameter validation failed: {}".format(ve.message))
+        except ValueError as ve:
+            return HttpResponseBadRequest("Parameter validation failed: {}".format(ve))
 
 
 @method_decorator(csrf_exempt, name="dispatch")
@@ -502,24 +556,30 @@ class StoreInventory(View):
         :param self: A StoreInventory instance
         :param request: An HttpRequest
         """
-        result = Stubs.getInventory(request, )
+        try:
 
-        if type(result) is tuple:
-            result, headers = result
-        else:
-            headers = {}
+            result = Stubs.getInventory(request, )
 
-        # The result may contain fields with date or datetime values that will not
-        # pass JSON validation. We first create the response, and then maybe validate
-        # the response content against the schema.
-        response = JsonResponse(result, safe=False)
+            if type(result) is tuple:
+                result, headers = result
+            else:
+                headers = {}
 
-        maybe_validate_result(response.content, self.GET_RESPONSE_SCHEMA)
+            # The result may contain fields with date or datetime values that will not
+            # pass JSON validation. We first create the response, and then maybe validate
+            # the response content against the schema.
+            response = JsonResponse(result, safe=False)
 
-        for key, val in headers.items():
-            response[key] = val
+            maybe_validate_result(response.content, self.GET_RESPONSE_SCHEMA)
 
-        return response
+            for key, val in headers.items():
+                response[key] = val
+
+            return response
+        except ValidationError as ve:
+            return HttpResponseBadRequest("Parameter validation failed: {}".format(ve.message))
+        except ValueError as ve:
+            return HttpResponseBadRequest("Parameter validation failed: {}".format(ve))
 
 
 @method_decorator(csrf_exempt, name="dispatch")
@@ -537,24 +597,30 @@ class StoreOrder(View):
         if not body:
             return HttpResponseBadRequest("Body required")
 
-        result = Stubs.placeOrder(request, body, )
+        try:
 
-        if type(result) is tuple:
-            result, headers = result
-        else:
-            headers = {}
+            result = Stubs.placeOrder(request, body, )
 
-        # The result may contain fields with date or datetime values that will not
-        # pass JSON validation. We first create the response, and then maybe validate
-        # the response content against the schema.
-        response = JsonResponse(result, safe=False)
+            if type(result) is tuple:
+                result, headers = result
+            else:
+                headers = {}
 
-        maybe_validate_result(response.content, self.POST_RESPONSE_SCHEMA)
+            # The result may contain fields with date or datetime values that will not
+            # pass JSON validation. We first create the response, and then maybe validate
+            # the response content against the schema.
+            response = JsonResponse(result, safe=False)
 
-        for key, val in headers.items():
-            response[key] = val
+            maybe_validate_result(response.content, self.POST_RESPONSE_SCHEMA)
 
-        return response
+            for key, val in headers.items():
+                response[key] = val
+
+            return response
+        except ValidationError as ve:
+            return HttpResponseBadRequest("Parameter validation failed: {}".format(ve.message))
+        except ValueError as ve:
+            return HttpResponseBadRequest("Parameter validation failed: {}".format(ve))
 
 
 @method_decorator(csrf_exempt, name="dispatch")
@@ -569,24 +635,30 @@ class StoreOrderOrderId(View):
         :param request: An HttpRequest
         :param orderId: string ID of the order that needs to be deleted
         """
-        result = Stubs.deleteOrder(request, orderId, )
+        try:
 
-        if type(result) is tuple:
-            result, headers = result
-        else:
-            headers = {}
+            result = Stubs.deleteOrder(request, orderId, )
 
-        # The result may contain fields with date or datetime values that will not
-        # pass JSON validation. We first create the response, and then maybe validate
-        # the response content against the schema.
-        response = JsonResponse(result, safe=False)
+            if type(result) is tuple:
+                result, headers = result
+            else:
+                headers = {}
 
-        maybe_validate_result(response.content, self.DELETE_RESPONSE_SCHEMA)
+            # The result may contain fields with date or datetime values that will not
+            # pass JSON validation. We first create the response, and then maybe validate
+            # the response content against the schema.
+            response = JsonResponse(result, safe=False)
 
-        for key, val in headers.items():
-            response[key] = val
+            maybe_validate_result(response.content, self.DELETE_RESPONSE_SCHEMA)
 
-        return response
+            for key, val in headers.items():
+                response[key] = val
+
+            return response
+        except ValidationError as ve:
+            return HttpResponseBadRequest("Parameter validation failed: {}".format(ve.message))
+        except ValueError as ve:
+            return HttpResponseBadRequest("Parameter validation failed: {}".format(ve))
 
     def get(self, request, orderId, *args, **kwargs):
         """
@@ -594,24 +666,30 @@ class StoreOrderOrderId(View):
         :param request: An HttpRequest
         :param orderId: string ID of pet that needs to be fetched
         """
-        result = Stubs.getOrderById(request, orderId, )
+        try:
 
-        if type(result) is tuple:
-            result, headers = result
-        else:
-            headers = {}
+            result = Stubs.getOrderById(request, orderId, )
 
-        # The result may contain fields with date or datetime values that will not
-        # pass JSON validation. We first create the response, and then maybe validate
-        # the response content against the schema.
-        response = JsonResponse(result, safe=False)
+            if type(result) is tuple:
+                result, headers = result
+            else:
+                headers = {}
 
-        maybe_validate_result(response.content, self.GET_RESPONSE_SCHEMA)
+            # The result may contain fields with date or datetime values that will not
+            # pass JSON validation. We first create the response, and then maybe validate
+            # the response content against the schema.
+            response = JsonResponse(result, safe=False)
 
-        for key, val in headers.items():
-            response[key] = val
+            maybe_validate_result(response.content, self.GET_RESPONSE_SCHEMA)
 
-        return response
+            for key, val in headers.items():
+                response[key] = val
+
+            return response
+        except ValidationError as ve:
+            return HttpResponseBadRequest("Parameter validation failed: {}".format(ve.message))
+        except ValueError as ve:
+            return HttpResponseBadRequest("Parameter validation failed: {}".format(ve))
 
 
 @method_decorator(csrf_exempt, name="dispatch")
@@ -629,24 +707,30 @@ class User(View):
         if not body:
             return HttpResponseBadRequest("Body required")
 
-        result = Stubs.createUser(request, body, )
+        try:
 
-        if type(result) is tuple:
-            result, headers = result
-        else:
-            headers = {}
+            result = Stubs.createUser(request, body, )
 
-        # The result may contain fields with date or datetime values that will not
-        # pass JSON validation. We first create the response, and then maybe validate
-        # the response content against the schema.
-        response = JsonResponse(result, safe=False)
+            if type(result) is tuple:
+                result, headers = result
+            else:
+                headers = {}
 
-        maybe_validate_result(response.content, self.POST_RESPONSE_SCHEMA)
+            # The result may contain fields with date or datetime values that will not
+            # pass JSON validation. We first create the response, and then maybe validate
+            # the response content against the schema.
+            response = JsonResponse(result, safe=False)
 
-        for key, val in headers.items():
-            response[key] = val
+            maybe_validate_result(response.content, self.POST_RESPONSE_SCHEMA)
 
-        return response
+            for key, val in headers.items():
+                response[key] = val
+
+            return response
+        except ValidationError as ve:
+            return HttpResponseBadRequest("Parameter validation failed: {}".format(ve.message))
+        except ValueError as ve:
+            return HttpResponseBadRequest("Parameter validation failed: {}".format(ve))
 
 
 @method_decorator(csrf_exempt, name="dispatch")
@@ -703,24 +787,30 @@ class UserCreateWithArray(View):
         if not body:
             return HttpResponseBadRequest("Body required")
 
-        result = Stubs.createUsersWithArrayInput(request, body, )
+        try:
 
-        if type(result) is tuple:
-            result, headers = result
-        else:
-            headers = {}
+            result = Stubs.createUsersWithArrayInput(request, body, )
 
-        # The result may contain fields with date or datetime values that will not
-        # pass JSON validation. We first create the response, and then maybe validate
-        # the response content against the schema.
-        response = JsonResponse(result, safe=False)
+            if type(result) is tuple:
+                result, headers = result
+            else:
+                headers = {}
 
-        maybe_validate_result(response.content, self.POST_RESPONSE_SCHEMA)
+            # The result may contain fields with date or datetime values that will not
+            # pass JSON validation. We first create the response, and then maybe validate
+            # the response content against the schema.
+            response = JsonResponse(result, safe=False)
 
-        for key, val in headers.items():
-            response[key] = val
+            maybe_validate_result(response.content, self.POST_RESPONSE_SCHEMA)
 
-        return response
+            for key, val in headers.items():
+                response[key] = val
+
+            return response
+        except ValidationError as ve:
+            return HttpResponseBadRequest("Parameter validation failed: {}".format(ve.message))
+        except ValueError as ve:
+            return HttpResponseBadRequest("Parameter validation failed: {}".format(ve))
 
 
 @method_decorator(csrf_exempt, name="dispatch")
@@ -777,24 +867,30 @@ class UserCreateWithList(View):
         if not body:
             return HttpResponseBadRequest("Body required")
 
-        result = Stubs.createUsersWithListInput(request, body, )
+        try:
 
-        if type(result) is tuple:
-            result, headers = result
-        else:
-            headers = {}
+            result = Stubs.createUsersWithListInput(request, body, )
 
-        # The result may contain fields with date or datetime values that will not
-        # pass JSON validation. We first create the response, and then maybe validate
-        # the response content against the schema.
-        response = JsonResponse(result, safe=False)
+            if type(result) is tuple:
+                result, headers = result
+            else:
+                headers = {}
 
-        maybe_validate_result(response.content, self.POST_RESPONSE_SCHEMA)
+            # The result may contain fields with date or datetime values that will not
+            # pass JSON validation. We first create the response, and then maybe validate
+            # the response content against the schema.
+            response = JsonResponse(result, safe=False)
 
-        for key, val in headers.items():
-            response[key] = val
+            maybe_validate_result(response.content, self.POST_RESPONSE_SCHEMA)
 
-        return response
+            for key, val in headers.items():
+                response[key] = val
+
+            return response
+        except ValidationError as ve:
+            return HttpResponseBadRequest("Parameter validation failed: {}".format(ve.message))
+        except ValueError as ve:
+            return HttpResponseBadRequest("Parameter validation failed: {}".format(ve))
 
 
 @method_decorator(csrf_exempt, name="dispatch")
@@ -809,28 +905,40 @@ class UserLogin(View):
         :param self: A UserLogin instance
         :param request: An HttpRequest
         """
-        # username (optional): string The user name for login
-        username = request.GET.get("username", None)
-        # password (optional): string The password for login in clear text
-        password = request.GET.get("password", None)
-        result = Stubs.loginUser(request, username, password, )
+        try:
 
-        if type(result) is tuple:
-            result, headers = result
-        else:
-            headers = {}
+            # username (optional): string The user name for login
+            username = request.GET.get("username", None)
+            if username is not None:
+                schema = {'type': 'string'}
+                utils.validate(username, schema)
+            # password (optional): string The password for login in clear text
+            password = request.GET.get("password", None)
+            if password is not None:
+                schema = {'type': 'string'}
+                utils.validate(password, schema)
+            result = Stubs.loginUser(request, username, password, )
 
-        # The result may contain fields with date or datetime values that will not
-        # pass JSON validation. We first create the response, and then maybe validate
-        # the response content against the schema.
-        response = JsonResponse(result, safe=False)
+            if type(result) is tuple:
+                result, headers = result
+            else:
+                headers = {}
 
-        maybe_validate_result(response.content, self.GET_RESPONSE_SCHEMA)
+            # The result may contain fields with date or datetime values that will not
+            # pass JSON validation. We first create the response, and then maybe validate
+            # the response content against the schema.
+            response = JsonResponse(result, safe=False)
 
-        for key, val in headers.items():
-            response[key] = val
+            maybe_validate_result(response.content, self.GET_RESPONSE_SCHEMA)
 
-        return response
+            for key, val in headers.items():
+                response[key] = val
+
+            return response
+        except ValidationError as ve:
+            return HttpResponseBadRequest("Parameter validation failed: {}".format(ve.message))
+        except ValueError as ve:
+            return HttpResponseBadRequest("Parameter validation failed: {}".format(ve))
 
 
 @method_decorator(csrf_exempt, name="dispatch")
@@ -843,24 +951,30 @@ class UserLogout(View):
         :param self: A UserLogout instance
         :param request: An HttpRequest
         """
-        result = Stubs.logoutUser(request, )
+        try:
 
-        if type(result) is tuple:
-            result, headers = result
-        else:
-            headers = {}
+            result = Stubs.logoutUser(request, )
 
-        # The result may contain fields with date or datetime values that will not
-        # pass JSON validation. We first create the response, and then maybe validate
-        # the response content against the schema.
-        response = JsonResponse(result, safe=False)
+            if type(result) is tuple:
+                result, headers = result
+            else:
+                headers = {}
 
-        maybe_validate_result(response.content, self.GET_RESPONSE_SCHEMA)
+            # The result may contain fields with date or datetime values that will not
+            # pass JSON validation. We first create the response, and then maybe validate
+            # the response content against the schema.
+            response = JsonResponse(result, safe=False)
 
-        for key, val in headers.items():
-            response[key] = val
+            maybe_validate_result(response.content, self.GET_RESPONSE_SCHEMA)
 
-        return response
+            for key, val in headers.items():
+                response[key] = val
+
+            return response
+        except ValidationError as ve:
+            return HttpResponseBadRequest("Parameter validation failed: {}".format(ve.message))
+        except ValueError as ve:
+            return HttpResponseBadRequest("Parameter validation failed: {}".format(ve))
 
 
 @method_decorator(csrf_exempt, name="dispatch")
@@ -877,24 +991,30 @@ class UserUsername(View):
         :param request: An HttpRequest
         :param username: string The name that needs to be deleted
         """
-        result = Stubs.deleteUser(request, username, )
+        try:
 
-        if type(result) is tuple:
-            result, headers = result
-        else:
-            headers = {}
+            result = Stubs.deleteUser(request, username, )
 
-        # The result may contain fields with date or datetime values that will not
-        # pass JSON validation. We first create the response, and then maybe validate
-        # the response content against the schema.
-        response = JsonResponse(result, safe=False)
+            if type(result) is tuple:
+                result, headers = result
+            else:
+                headers = {}
 
-        maybe_validate_result(response.content, self.DELETE_RESPONSE_SCHEMA)
+            # The result may contain fields with date or datetime values that will not
+            # pass JSON validation. We first create the response, and then maybe validate
+            # the response content against the schema.
+            response = JsonResponse(result, safe=False)
 
-        for key, val in headers.items():
-            response[key] = val
+            maybe_validate_result(response.content, self.DELETE_RESPONSE_SCHEMA)
 
-        return response
+            for key, val in headers.items():
+                response[key] = val
+
+            return response
+        except ValidationError as ve:
+            return HttpResponseBadRequest("Parameter validation failed: {}".format(ve.message))
+        except ValueError as ve:
+            return HttpResponseBadRequest("Parameter validation failed: {}".format(ve))
 
     def get(self, request, username, *args, **kwargs):
         """
@@ -902,24 +1022,30 @@ class UserUsername(View):
         :param request: An HttpRequest
         :param username: string The name that needs to be fetched. Use user1 for testing. 
         """
-        result = Stubs.getUserByName(request, username, )
+        try:
 
-        if type(result) is tuple:
-            result, headers = result
-        else:
-            headers = {}
+            result = Stubs.getUserByName(request, username, )
 
-        # The result may contain fields with date or datetime values that will not
-        # pass JSON validation. We first create the response, and then maybe validate
-        # the response content against the schema.
-        response = JsonResponse(result, safe=False)
+            if type(result) is tuple:
+                result, headers = result
+            else:
+                headers = {}
 
-        maybe_validate_result(response.content, self.GET_RESPONSE_SCHEMA)
+            # The result may contain fields with date or datetime values that will not
+            # pass JSON validation. We first create the response, and then maybe validate
+            # the response content against the schema.
+            response = JsonResponse(result, safe=False)
 
-        for key, val in headers.items():
-            response[key] = val
+            maybe_validate_result(response.content, self.GET_RESPONSE_SCHEMA)
 
-        return response
+            for key, val in headers.items():
+                response[key] = val
+
+            return response
+        except ValidationError as ve:
+            return HttpResponseBadRequest("Parameter validation failed: {}".format(ve.message))
+        except ValueError as ve:
+            return HttpResponseBadRequest("Parameter validation failed: {}".format(ve))
 
     def put(self, request, username, *args, **kwargs):
         """
@@ -931,24 +1057,30 @@ class UserUsername(View):
         if not body:
             return HttpResponseBadRequest("Body required")
 
-        result = Stubs.updateUser(request, body, username, )
+        try:
 
-        if type(result) is tuple:
-            result, headers = result
-        else:
-            headers = {}
+            result = Stubs.updateUser(request, body, username, )
 
-        # The result may contain fields with date or datetime values that will not
-        # pass JSON validation. We first create the response, and then maybe validate
-        # the response content against the schema.
-        response = JsonResponse(result, safe=False)
+            if type(result) is tuple:
+                result, headers = result
+            else:
+                headers = {}
 
-        maybe_validate_result(response.content, self.PUT_RESPONSE_SCHEMA)
+            # The result may contain fields with date or datetime values that will not
+            # pass JSON validation. We first create the response, and then maybe validate
+            # the response content against the schema.
+            response = JsonResponse(result, safe=False)
 
-        for key, val in headers.items():
-            response[key] = val
+            maybe_validate_result(response.content, self.PUT_RESPONSE_SCHEMA)
 
-        return response
+            for key, val in headers.items():
+                response[key] = val
+
+            return response
+        except ValidationError as ve:
+            return HttpResponseBadRequest("Parameter validation failed: {}".format(ve.message))
+        except ValueError as ve:
+            return HttpResponseBadRequest("Parameter validation failed: {}".format(ve))
 
 
 class __SWAGGER_SPEC__(View):
@@ -1143,7 +1275,7 @@ class __SWAGGER_SPEC__(View):
         },
         "description": "This is a sample server Petstore server.  You can find out more about Swagger at <a href=\\"http://swagger.io\\">http://swagger.io</a> or on irc.freenode.net, #swagger.  For this sample, you can use the api key \\"special-key\\" to test the authorization filters",
         "license": {
-            "name": "Apache 2.0",
+            "name": "Apache-2.0",
             "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
         },
         "termsOfService": "http://helloreverb.com/terms/",
@@ -1314,6 +1446,7 @@ class __SWAGGER_SPEC__(View):
         },
         "/pet/findByTags": {
             "get": {
+                "deprecated": true,
                 "description": "Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.",
                 "operationId": "findPetsByTags",
                 "parameters": [

--- a/swagger_django_generator/generator.py
+++ b/swagger_django_generator/generator.py
@@ -73,6 +73,13 @@ if major > 3 or major == 3 and minor >= 5:
 # * Paths map to class based views.
 # * (path, http_verb) combinations map to operations.
 
+# Swagger fields used in parameter definition, but which are unknown to jsonschema.
+_SWAGGER_FIELDS = frozenset(["name", "in", "required", "collectionFormat"])
+
+
+def clean_schema(schema):
+    return {k: v for k, v in schema.items() if k not in _SWAGGER_FIELDS}
+
 
 def render_to_string(backend, filename, context):
     # type: (str, str, Dict) -> str
@@ -91,11 +98,14 @@ def render_to_string(backend, filename, context):
     except ImportError:
         pass
 
-    return jinja2.Environment(
+    environment = jinja2.Environment(
         loader=jinja2.ChoiceLoader(loaders),
         trim_blocks=True,
-        lstrip_blocks=True
-    ).get_template(filename).render(context)
+        lstrip_blocks=True,
+    )
+    environment.filters["clean_schema"] = clean_schema
+
+    return environment.get_template(filename).render(context)
 
 
 def path_to_class_name(path):

--- a/swagger_django_generator/generator.py
+++ b/swagger_django_generator/generator.py
@@ -83,6 +83,19 @@ def clean_schema(schema):
     return {k: v for k, v in schema.items() if k not in _SWAGGER_FIELDS}
 
 
+def parse_array(schema):
+    separators = {
+        "pipes": "|",
+        "tsv": "\t",
+        "ssv": " ",
+        "csv": ","
+    }
+    return '{name} = {name}.split("{separator}")  # New'.format(
+        name=schema["name"],
+        separator=separators[schema["collectionFormat"]]
+    )
+
+
 def render_to_string(backend, filename, context):
     # type: (str, str, Dict) -> str
     """
@@ -106,6 +119,7 @@ def render_to_string(backend, filename, context):
         lstrip_blocks=True,
     )
     environment.filters["clean_schema"] = clean_schema
+    environment.filters["parse_array"] = parse_array
 
     return environment.get_template(filename).render(context)
 

--- a/swagger_django_generator/generator.py
+++ b/swagger_django_generator/generator.py
@@ -74,10 +74,12 @@ if major > 3 or major == 3 and minor >= 5:
 # * (path, http_verb) combinations map to operations.
 
 # Swagger fields used in parameter definition, but which are unknown to jsonschema.
-_SWAGGER_FIELDS = frozenset(["name", "in", "required", "collectionFormat"])
+_SWAGGER_FIELDS = frozenset(["name", "in", "required", "collectionFormat", "description"])
 
 
 def clean_schema(schema):
+    # type: (Dict) -> Dict
+    """Transform a Swagger parameter definition to a valid JSONSchema"""
     return {k: v for k, v in schema.items() if k not in _SWAGGER_FIELDS}
 
 

--- a/swagger_django_generator/generator.py
+++ b/swagger_django_generator/generator.py
@@ -83,16 +83,19 @@ def clean_schema(schema):
     return {k: v for k, v in schema.items() if k not in _SWAGGER_FIELDS}
 
 
+SEPARATORS = {
+    "pipes": "|",
+    "tsv": "\t",
+    "ssv": " ",
+    "csv": ","
+}
+
+
 def parse_array(schema):
-    separators = {
-        "pipes": "|",
-        "tsv": "\t",
-        "ssv": " ",
-        "csv": ","
-    }
-    return '{name} = {name}.split("{separator}")  # New'.format(
+    # type: (Dict) -> string
+    return '{name} = {name}.split("{separator}")'.format(
         name=schema["name"],
-        separator=separators[schema["collectionFormat"]]
+        separator=SEPARATORS[schema.get("collectionFormat", ",")]
     )
 
 

--- a/swagger_django_generator/templates/django/utils.py
+++ b/swagger_django_generator/templates/django/utils.py
@@ -98,6 +98,9 @@ _FORMAT_CHECKER = jsonschema.FormatChecker()
 _LOGGER.info("The following formats will be validated: {}".format(
              ", ".join(_FORMAT_CHECKER.checkers.keys())))
 
+# Swagger fields used in parameter definition, but which are unknown to jsonschema.
+_SWAGGER_FIELDS = frozenset(["name", "in", "required", "collectionFormat"])
+
 
 def validate(instance, schema):
     jsonschema.validate(instance, schema=schema,
@@ -105,8 +108,4 @@ def validate(instance, schema):
 
 
 def clean_schema(schema):
-    result = copy.copy(schema)
-    for field in ["name", "in", "required", "collectionFormat"]:
-        del result[field]
-
-    return result
+    return {k: v for k, v in schema.items() if k not in _SWAGGER_FIELDS}

--- a/swagger_django_generator/templates/django/utils.py
+++ b/swagger_django_generator/templates/django/utils.py
@@ -4,7 +4,6 @@ Do not modify this file. It is generated from the Swagger specification.
 If you need to tweak the functionality in this file, you can replace it
 with your own.
 """
-import copy
 from functools import wraps
 import base64
 import json
@@ -98,14 +97,7 @@ _FORMAT_CHECKER = jsonschema.FormatChecker()
 _LOGGER.info("The following formats will be validated: {}".format(
              ", ".join(_FORMAT_CHECKER.checkers.keys())))
 
-# Swagger fields used in parameter definition, but which are unknown to jsonschema.
-_SWAGGER_FIELDS = frozenset(["name", "in", "required", "collectionFormat"])
-
 
 def validate(instance, schema):
     jsonschema.validate(instance, schema=schema,
                         format_checker=_FORMAT_CHECKER)
-
-
-def clean_schema(schema):
-    return {k: v for k, v in schema.items() if k not in _SWAGGER_FIELDS}

--- a/swagger_django_generator/templates/django/utils.py
+++ b/swagger_django_generator/templates/django/utils.py
@@ -4,6 +4,7 @@ Do not modify this file. It is generated from the Swagger specification.
 If you need to tweak the functionality in this file, you can replace it
 with your own.
 """
+import copy
 from functools import wraps
 import base64
 import json
@@ -101,3 +102,11 @@ _LOGGER.info("The following formats will be validated: {}".format(
 def validate(instance, schema):
     jsonschema.validate(instance, schema=schema,
                         format_checker=_FORMAT_CHECKER)
+
+
+def clean_schema(schema):
+    result = copy.copy(schema)
+    for field in ["name", "in", "required", "collectionFormat"]:
+        del result[field]
+
+    return result

--- a/swagger_django_generator/templates/django/views.py
+++ b/swagger_django_generator/templates/django/views.py
@@ -91,17 +91,6 @@ class {{ class_name }}(View):
             {{ ra.name }} = request.GET.get("{{ ra.name }}", None)
             if {{ ra.name }} is not None:
                 {{ ra|parse_array }}
-          {% if ra.collectionFormat == "pipes" %}
-                {{ ra.name }} = {{ ra.name }}.split("|")
-          {% elif ra.collectionFormat == "tsv" %}
-                {{ ra.name }} = {{ ra.name }}.split("\t")
-          {% elif ra.collectionFormat == "ssv" %}
-                {{ ra.name }} = {{ ra.name }}.split(" ")
-          {% elif ra.collectionFormat == "csv" %}
-                {{ ra.name }} = {{ ra.name }}.split(",")
-          {% else %}
-                {{ ra.name }} = {{ ra.name }}.split(",")
-          {% endif %}
           {% if ra["items"].type == "integer" %}
                 if {{ ra.name }}:
                     {{ ra.name }} = [int(e) for e in {{ ra.name }}]
@@ -129,17 +118,7 @@ class {{ class_name }}(View):
         {% else %}
             {{ oa.name }} = request.GET.get("{{ oa.name }}", None)
             if {{ oa.name }} is not None:
-          {% if oa.collectionFormat == "pipes" %}
-                {{ oa.name }} = {{ oa.name }}.split("|")
-          {% elif oa.collectionFormat == "tsv" %}
-                {{ oa.name }} = {{ oa.name }}.split("\t")
-          {% elif oa.collectionFormat == "ssv" %}
-                {{ oa.name }} = {{ oa.name }}.split(" ")
-          {% elif oa.collectionFormat == "csv" %}
-                {{ oa.name }} = {{ oa.name }}.split(",")
-          {% else %}
-                {{ oa.name }} = {{ oa.name }}.split(",")
-          {% endif %}
+                {{ oa|parse_array }}
           {% if oa["items"].type == "integer" %}
                 if {{ oa.name }}:
                     {{ oa.name }} = [int(e) for e in {{ oa.name }}]

--- a/swagger_django_generator/templates/django/views.py
+++ b/swagger_django_generator/templates/django/views.py
@@ -101,6 +101,10 @@ class {{ class_name }}(View):
           {% else %}
                 {{ ra.name }} = {{ ra.name }}.split(",")
           {% endif %}
+          {% if ra["items"].type == "integer" %}
+                if {{ ra.name }}:
+                    {{ ra.name }} = [int(e) for e in {{ ra.name }}]
+          {% endif %}
         {% endif %}
       {% else %}
             {{ ra.name }} = request.GET.get("{{ ra.name }}")
@@ -139,6 +143,10 @@ class {{ class_name }}(View):
                 {{ oa.name }} = {{ oa.name }}.split(",")
           {% else %}
                 {{ oa.name }} = {{ oa.name }}.split(",")
+          {% endif %}
+          {% if oa["items"].type == "integer" %}
+                if {{ oa.name }}:
+                    {{ oa.name }} = [int(e) for e in {{ oa.name }}]
           {% endif %}
         {% endif %}
       {% else %}

--- a/swagger_django_generator/templates/django/views.py
+++ b/swagger_django_generator/templates/django/views.py
@@ -90,6 +90,7 @@ class {{ class_name }}(View):
         {% else %}
             {{ ra.name }} = request.GET.get("{{ ra.name }}", None)
             if {{ ra.name }} is not None:
+                {{ ra|parse_array }}
           {% if ra.collectionFormat == "pipes" %}
                 {{ ra.name }} = {{ ra.name }}.split("|")
           {% elif ra.collectionFormat == "tsv" %}
@@ -114,13 +115,6 @@ class {{ class_name }}(View):
             {{ ra.name }} = ({{ ra.name }}.lower() == "true")
       {% elif ra.type == "integer" %}
             {{ ra.name }} = int({{ ra.name }})
-            #schema = {{ ra|clean_schema }}
-            #utils.validate({{ ra.name }}, schema)
-      {% elif ra.type == "string" %}
-            #schema = {{ ra|clean_schema }}
-            #utils.validate({{ ra.name }}, schema)
-      {% else %}
-            #utils.validate({{ ra.name }}, {"type": "{{ ra.type }}"})
       {% endif %}
             schema = {{ ra|clean_schema }}
             utils.validate({{ ra.name }}, schema)
@@ -159,14 +153,6 @@ class {{ class_name }}(View):
                 {{ oa.name }} = ({{ oa.name }}.lower() == "true")
       {% elif oa.type == "integer" %}
                 {{ oa.name }} = int({{ oa.name }})
-      {% elif oa.type == "array" %}
-                #schema = {{ oa|clean_schema }}
-                #utils.validate({{ oa.name }}, schema)
-      {% elif oa.type == "string" %}
-                #schema = {{ oa|clean_schema }}
-                #utils.validate({{ oa.name }}, schema)
-      {% else %}
-                #utils.validate({{ oa.name }}, {"type": "{{ oa.type }}"})
       {% endif %}
                 schema = {{ oa|clean_schema }}
                 utils.validate({{ oa.name }}, schema)

--- a/swagger_django_generator/templates/django/views.py
+++ b/swagger_django_generator/templates/django/views.py
@@ -131,7 +131,10 @@ class {{ class_name }}(View):
         {% else %}
         {{ oa.name }} = request.GET.get("{{ oa.name }}", None)
         {% endif %}
-        utils.validate({{ oa.name }}, {"type": "{{ oa.type }}"})
+        utils.validate({{ oa.name }}, {
+            "type": "{{ oa.type }}",
+            {% if oa.format %}"format": "{{ oa.format }}"{% endif %}
+        })
         {% endfor %}
         {% if info.form_data %}
         form_data = {}

--- a/swagger_django_generator/templates/django/views.py
+++ b/swagger_django_generator/templates/django/views.py
@@ -112,17 +112,19 @@ class {{ class_name }}(View):
 
       {% if ra.type == "boolean" %}
             {{ ra.name }} = ({{ ra.name }}.lower() == "true")
-      {% endif %}
-      {% if ra.type == "integer" %}
+      {% elif ra.type == "integer" %}
             {{ ra.name }} = int({{ ra.name }})
-            schema = {{ ra|clean_schema }}
-            utils.validate({{ ra.name }}, schema)
+            #schema = {{ ra|clean_schema }}
+            #utils.validate({{ ra.name }}, schema)
       {% elif ra.type == "string" %}
+            #schema = {{ ra|clean_schema }}
+            #utils.validate({{ ra.name }}, schema)
+      {% else %}
+            #utils.validate({{ ra.name }}, {"type": "{{ ra.type }}"})
+      {% endif %}
             schema = {{ ra|clean_schema }}
             utils.validate({{ ra.name }}, schema)
-      {% else %}
-            utils.validate({{ ra.name }}, {"type": "{{ ra.type }}"})
-      {% endif %}
+
     {% endfor %}
 
     {% for oa in info.optional_args if oa.in == "query" %}
@@ -155,18 +157,19 @@ class {{ class_name }}(View):
             if {{ oa.name }} is not None:
       {% if oa.type == "boolean" %}
                 {{ oa.name }} = ({{ oa.name }}.lower() == "true")
-      {% endif %}
-      {% if oa.type == "integer" %}
+      {% elif oa.type == "integer" %}
                 {{ oa.name }} = int({{ oa.name }})
       {% elif oa.type == "array" %}
-                schema = {{ oa|clean_schema }}
-                utils.validate({{ oa.name }}, schema)
+                #schema = {{ oa|clean_schema }}
+                #utils.validate({{ oa.name }}, schema)
       {% elif oa.type == "string" %}
+                #schema = {{ oa|clean_schema }}
+                #utils.validate({{ oa.name }}, schema)
+      {% else %}
+                #utils.validate({{ oa.name }}, {"type": "{{ oa.type }}"})
+      {% endif %}
                 schema = {{ oa|clean_schema }}
                 utils.validate({{ oa.name }}, schema)
-      {% else %}
-                utils.validate({{ oa.name }}, {"type": "{{ oa.type }}"})
-      {% endif %}
     {% endfor %}
     {% if info.form_data %}
             form_data = {}

--- a/swagger_django_generator/templates/django/views.py
+++ b/swagger_django_generator/templates/django/views.py
@@ -115,10 +115,10 @@ class {{ class_name }}(View):
       {% endif %}
       {% if ra.type == "integer" %}
             {{ ra.name }} = int({{ ra.name }})
-            schema = utils.clean_schema({{ ra }})
+            schema = {{ ra|clean_schema }}
             utils.validate({{ ra.name }}, schema)
       {% elif ra.type == "string" %}
-            schema = utils.clean_schema({{ ra }})
+            schema = {{ ra|clean_schema }}
             utils.validate({{ ra.name }}, schema)
       {% else %}
             utils.validate({{ ra.name }}, {"type": "{{ ra.type }}"})
@@ -159,10 +159,10 @@ class {{ class_name }}(View):
       {% if oa.type == "integer" %}
                 {{ oa.name }} = int({{ oa.name }})
       {% elif oa.type == "array" %}
-                schema = utils.clean_schema({{ oa }})
+                schema = {{ oa|clean_schema }}
                 utils.validate({{ oa.name }}, schema)
       {% elif oa.type == "string" %}
-                schema = utils.clean_schema({{ oa }})
+                schema = {{ oa|clean_schema }}
                 utils.validate({{ oa.name }}, schema)
       {% else %}
                 utils.validate({{ oa.name }}, {"type": "{{ oa.type }}"})

--- a/swagger_django_generator/templates/django/views.py
+++ b/swagger_django_generator/templates/django/views.py
@@ -105,7 +105,9 @@ class {{ class_name }}(View):
         {{ ra.name }} = request.GET.get("{{ ra.name }}")
         {% endif %}
 
+        utils.validate({{ ra.name }}, {"type": "{{ ra.type }}"})
         {% endfor %}
+
         {% for oa in info.optional_args if oa.in == "query" %}
         # {{ oa.name }} (optional): {{ oa.type }} {{ oa.description }}
         {% if oa.type == "array" %}
@@ -129,6 +131,7 @@ class {{ class_name }}(View):
         {% else %}
         {{ oa.name }} = request.GET.get("{{ oa.name }}", None)
         {% endif %}
+        utils.validate({{ oa.name }}, {"type": "{{ oa.type }}"})
         {% endfor %}
         {% if info.form_data %}
         form_data = {}

--- a/swagger_django_generator/templates/django/views.py
+++ b/swagger_django_generator/templates/django/views.py
@@ -131,10 +131,8 @@ class {{ class_name }}(View):
         {% else %}
         {{ oa.name }} = request.GET.get("{{ oa.name }}", None)
         {% endif %}
-        utils.validate({{ oa.name }}, {
-            "type": "{{ oa.type }}",
-            {% if oa.format %}"format": "{{ oa.format }}"{% endif %}
-        })
+        if {{ oa.name }} is not None:
+            utils.validate({{ oa.name }}, {"type": "{{ oa.type }}", {% if oa.format %}"format": "{{ oa.format }}"{% endif %} })
         {% endfor %}
         {% if info.form_data %}
         form_data = {}

--- a/tests/resources/authentication_service.yml
+++ b/tests/resources/authentication_service.yml
@@ -1,0 +1,1336 @@
+swagger: '2.0'
+
+schemes:
+  - https
+  - http
+
+info:
+  title: Authentication Service API
+  description: >
+    This is the API that will be exposed by the Authentication Service.
+
+    The Authentication Service facilitates user registration and login via web-based flows as defined for the
+    OpenID Connect specification.
+  version: '1.0'
+
+securityDefinitions:
+  APIKeyHeader:
+    type: apiKey
+    in: header
+    name: X-API-Key
+
+#  OAuth2:
+#    type: oauth2
+#    flow: accessCode
+#    authorizationUrl: 'http://localhost:8000/openid/authorize'
+#    tokenUrl: 'http:///localhost:8000/openid/token'
+#    scopes:
+#      roles: Grants access to user roles
+#      site: Grants access to site-specific data
+
+#  client_secret:
+#    description: Session management by confidential clients.
+#    type: oauth2
+#    flow: password
+#    tokenUrl: 'http://localhost:8000/openid/token'
+#    scopes:
+#      clients: Enable client management
+
+#  client_registration_token:
+#    description: Client management via registration token.
+#    type: apiKey
+#    name: Authorization
+#    in: header
+
+#  user_jwt:
+#    description: Session management by Authentiq ID.
+#    type: oauth2
+#    flow: application
+#    tokenUrl: 'http://localhost:8000/openid/token'
+#    scopes:
+#      session: Enable session management
+
+#  oauth_code:
+#    description: End-user authentication.
+#    type: oauth2
+#    flow: accessCode
+#    authorizationUrl: 'http://locahost:8000/authorize'
+#    tokenUrl: 'http://locahost:8000/token'
+#    scopes:
+#      oidc: Enable OIDC flow
+#      email: The user's email address
+#      phone: The user's phone number
+#      address: The user's postal address
+#      'ge:roles': The user's roles
+#      'ge:site': The user's site-specific data
+
+#  oauth_implicit:
+#    description: End-user authentication.
+#    type: oauth2
+#    flow: implicit
+#    authorizationUrl: 'http://localhost:8000/authorize'
+#    scopes:
+#      oidc: Enable OIDC flow
+#      email: The user's email address
+#      phone: The user's phone number
+#      address: The user's postal address
+#      roles: The user's roles
+#      site: The user's site-specific data
+
+security:
+  - APIKeyHeader: []
+
+host: 'localhost:8000'
+
+basePath: /api/v1
+
+definitions:
+  country:
+    type: object
+    properties:
+      code:
+        type: string
+        minLength: 2
+        maxLength: 2
+      name:
+        type: string
+        maxLength: 100
+    required:
+      - code
+      - name
+
+  client:
+    type: object
+    properties:
+      id:
+        description: ''
+        type: integer
+      _post_logout_redirect_uris:
+        description: New-line delimited list of post-logout redirect URIs
+        type: string
+      _redirect_uris:
+        description: New-line delimited list of redirect URIs
+        type: string
+      client_id:
+        description: ''
+        type: string
+      contact_email:
+        description: ''
+        type: string
+      logo:
+        description: ''
+        type: string
+        format: uri
+      name:
+        description: ''
+        type: string
+      require_consent:
+        description: 'If disabled, the Server will NEVER ask the user for consent.'
+        type: boolean
+      response_type:
+        description: ''
+        type: string
+      reuse_consent:
+        description: >-
+          If enabled, the Server will save the user consent given to a
+          specific client, so that user won't be prompted for the same
+          authorization multiple times.
+        type: boolean
+      terms_url:
+        description: External reference to the privacy policy of the client.
+        type: string
+      website_url:
+        description: ''
+        type: string
+    required:
+      - id
+      - client_id
+      - response_type
+
+  organisation:
+    type: object
+    properties:
+      id:
+        type: integer
+      name:
+        type: string
+      description:
+        type: string
+      created_at:
+        type: string
+        format: date-time
+        readOnly: true
+      updated_at:
+        type: string
+        format: date-time
+        readOnly: true
+    required:
+      - id
+      - name
+      - description
+      - created_at
+      - updated_at
+
+  organisation_create:
+    type: object
+    properties:
+      name:
+        type: string
+      description:
+        type: string
+    required:
+      - name
+
+  organisation_update:
+    type: object
+    properties:
+      name:
+        type: string
+      description:
+        type: string
+    minProperties: 1
+
+  user:
+    type: object
+    properties:
+      id:
+        description: A UUID identifying the user
+        type: string
+        format: uuid
+        readOnly: true
+      username:
+        description: >-
+          Required. 150 characters or fewer. Letters, digits and
+          @/./+/-/_ only.
+        type: string
+        readOnly: true
+      first_name:
+        description: ''
+        type: string
+      last_name:
+        description: ''
+        type: string
+      email:
+        description: ''
+        type: string
+        format: email
+      is_active:
+        description: >-
+          Designates whether this user should be treated as active.
+          Deselect this instead of deleting accounts.
+        type: boolean
+      date_joined:
+        description: ''
+        type: string
+        format: date
+        readOnly: true
+      last_login:
+        description: ''
+        type: string
+        format: 'date-time'
+        readOnly: true
+      email_verified:
+        type: boolean
+      msisdn_verified:
+        type: boolean
+      msisdn:
+        type: string
+        maxLength: 15
+      gender:
+        type: string
+      birth_date:
+        type: string
+        format: date
+      avatar:
+        type: string
+        format: uri
+      country_code:
+        type: string
+        minLength: 2
+        maxLength: 2
+      organisation_id:
+        type: integer
+        readOnly: true
+      created_at:
+        type: string
+        format: date-time
+        readOnly: true
+      updated_at:
+        type: string
+        format: date-time
+        readOnly: true
+    required:
+      - id
+      - username
+      - is_active
+      - date_joined
+      - created_at
+      - updated_at
+
+  user_update:
+    type: object
+    properties:
+      first_name:
+        description: ''
+        type: string
+      last_name:
+        description: ''
+        type: string
+      email:
+        description: ''
+        type: string
+        format: email
+      is_active:
+        description: >-
+          Designates whether this user should be treated as active.
+          Deselect this instead of deleting accounts.
+        type: boolean
+      email_verified:
+        type: boolean
+      msisdn_verified:
+        type: boolean
+      msisdn:
+        type: string
+        maxLength: 15
+      gender:
+        type: string
+      birth_date:
+        type: string
+        format: date
+      avatar:
+        type: string
+        format: uri
+      country_code:
+        type: string
+        minLength: 2
+        maxLength: 2
+    minProperties: 1
+
+  user_site:
+    type: object
+    properties:
+      id:
+        type: integer
+      user_id:
+        type: string
+        format: uuid
+      site_id:
+        type: integer
+      consented_at:
+        type: string
+        format: 'date-time'
+      created_at:
+        type: string
+        format: date-time
+        readOnly: true
+      updated_at:
+        type: string
+        format: date-time
+        readOnly: true
+    required:
+      - id
+      - user_id
+      - site_id
+      - consented_at
+      - created_at
+      - updated_at
+  request_user_deletion:
+    type: object
+    properties:
+      user_id:
+        type: string
+        format: uuid
+      deleter_id:
+        type: string
+        format: uuid
+      reason:
+        type: string
+    required:
+      - user_id
+      - deleter_id
+      - reason
+
+#  Token:
+#    description: |
+#      Successful token response
+#    required:
+#      - token_type
+#    properties:
+#      token_type:
+#        type: string
+#      access_token:
+#        description: The access token issued by the authorization server.
+#        type: string
+#      id_token:
+#        description: ID Token value associated with the authenticated session.
+#        type: string
+#      refresh_token:
+#        description: 'The refresh token issued to the client, if any.'
+#        type: string
+#      expires_in:
+#        description: The lifetime in seconds of the access token.
+#        type: integer
+#        format: int32
+#      expires_at:
+#        description: The time the access token will expire in seconds since epoch.
+#        type: integer
+#        format: int64
+#      scope:
+#        description: The scope of the granted tokens.
+#        type: string
+
+#  OAuth2Error:
+#    description: |
+#      Error Response defined as in Section 5.2 of OAuth 2.0 [RFC6749].
+#    required:
+#      - error
+#    properties:
+#      error:
+#        type: string
+#      error_description:
+#        type: string
+
+#  ProblemDetail:
+#    description: |
+#      HTTP Problem Detail
+#    required:
+#      - type
+#      - status
+#    properties:
+#      type:
+#        type: string
+#        default: 'about:blank'
+#      title:
+#        type: string
+#        description: |
+#          Human-readable summary of the problem type.
+#      status:
+#        type: integer
+#        description: |
+#          The HTTP status code for this occurrence of the problem.
+#      detail:
+#        type: string
+#        description: >
+#          Human-readable explanation specific to this occurrence of the
+#          problem.
+
+#  Session:
+#    description: Session object
+#    properties:
+#      version:
+#        type: integer
+#      sub:
+#        type: string
+#      session_id:
+#        type: string
+#      session_state:
+#        type: string
+#      session_uri:
+#        type: string
+#      client_id:
+#        type: string
+#      scopes:
+#        type: array
+#        items:
+#          type: string
+#      scopes_optional:
+#        type: array
+#        items:
+#          type: string
+#      scopes_required:
+#        type: array
+#        items:
+#          type: string
+#      scopes_signed:
+#        type: array
+#        items:
+#          type: string
+#      tokens_seen:
+#        type: array
+#        items:
+#          type: string
+#      scopes_seen:
+#        type: array
+#        items:
+#          type: string
+#      redirect_uri:
+#        type: string
+#      response_type:
+#        type: string
+#      response_mode:
+#        type: string
+#      nonce:
+#        type: string
+#      created_at:
+#        type: string
+#      connected_at:
+#        type: string
+#        format: date-time
+#      authenticated_at:
+#        type: string
+#        format: date-time
+#      concluded_at:
+#        type: string
+#        format: date-time
+#      deleted_at:
+#        type: string
+#        format: date-time
+#      client_name:
+#        type: string
+#      client_uri:
+#        type: string
+#      logo_uri:
+#        type: string
+#      policy_uri:
+#        type: string
+#      tos_uri:
+#        type: string
+#      contacts:
+#        type: array
+#        items:
+#          type: string
+
+#  UserInfo:
+#    description: OIDC UserInfo structure
+#    required:
+#      - sub
+#    properties:
+#      sub:
+#        type: string
+#      name:
+#        type: string
+#      given_name:
+#        type: string
+#      family_name:
+#        type: string
+#      email:
+#        type: string
+#      email_verified:
+#        type: boolean
+#      phone_number:
+#        type: string
+#      phone_number_verified:
+#        type: boolean
+#      address:
+#        $ref: '#/definitions/Address'
+
+#  Address:
+#    description: OIDC Address structure
+#    properties:
+#      street_address:
+#        type: string
+#      locality:
+#        type: string
+#      region:
+#        type: string
+#      postal_code:
+#        type: string
+#      country:
+#        type: string
+
+#  Client:
+#    description: Client object
+#    required:
+#      - client_name
+#      - client_uri
+#    properties:
+#      client_id:
+#        type: string
+#      redirect_uris:
+#        type: array
+#        items:
+#          type: string
+#      response_types:
+#        type: array
+#        items:
+#          type: string
+#      grant_types:
+#        type: array
+#        items:
+#          type: string
+#      application_type:
+#        type: string
+#      contacts:
+#        type: array
+#        items:
+#          type: string
+#      client_name:
+#        type: string
+#      logo_uri:
+#        type: string
+#      client_uri:
+#        type: string
+#      policy_uri:
+#        type: string
+#      tos_uri:
+#        type: string
+#      default_max_age:
+#        type: integer
+#        format: int64
+#      default_scopes:
+#        type: array
+#        items:
+#          type: string
+
+parameters:
+  optional_limit:
+    description: An optional query parameter to limit the number of results returned.
+    in: query
+    name: limit
+    required: false
+    type: integer
+    minimum: 1
+    maximum: 100
+    default: 20
+  optional_offset:
+    description: >-
+      An optional query parameter specifying the offset in the result set to
+      start from.
+    in: query
+    name: offset
+    required: false
+    type: integer
+    default: 0
+    minimum: 0
+  optional_cutoff_date:
+    description: An optional cutoff date to purge invites before this date
+    in: query
+    name: cutoff_date
+    required: false
+    type: string
+    format: date
+  client_id:
+    description: A string value identifying the client
+    in: path
+    name: client_id
+    required: true
+    type: string
+  country_code:
+    description: A string value identifying the country
+    in: path
+    name: country_code
+    required: true
+    type: string
+    minLength: 2
+    maxLength: 2
+  organisation_id:
+    description: An integer identifying an organisation a user belongs to
+    in: path
+    name: organisation_id
+    required: true
+    type: integer
+  user_id:
+    description: A UUID value identifying the user.
+    in: path
+    name: user_id
+    required: true
+    type: string
+    format: uuid
+
+paths:
+  /clients:
+    get:
+      operationId: client_list
+      parameters:
+        - $ref: '#/parameters/optional_offset'
+        - $ref: '#/parameters/optional_limit'
+        - name: client_ids
+          description: An optional list of client ids
+          in: query
+          type: array
+          items:
+            type: integer
+          required: false
+          minItems: 1
+          collectionFormat: csv
+          uniqueItems: true
+        - description: An optional client id to filter on. This is not the primary key.
+          in: query
+          name: client_token_id
+          required: false
+          type: string
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: ''
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/client'
+          headers:
+            X-Total-Count:
+              type: integer
+              description: The total number of results matching the query
+      tags:
+        - authentication
+
+  /clients/{client_id}:
+    parameters:
+      - $ref: '#/parameters/client_id'
+    get:
+      operationId: client_read
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/client'
+      tags:
+        - authentication
+
+  /countries:
+    get:
+      operationId: country_list
+      parameters:
+        - $ref: '#/parameters/optional_offset'
+        - $ref: '#/parameters/optional_limit'
+        - name: country_codes
+          description: An optional list of country codes
+          in: query
+          type: array
+          items:
+            type: string
+            minLength: 2
+            maxLength: 2
+          required: false
+          minItems: 1
+          collectionFormat: csv
+          uniqueItems: true
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: ''
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/country'
+          headers:
+            X-Total-Count:
+              type: integer
+              description: The total number of results matching the query
+
+      tags:
+        - authentication
+
+  /countries/{country_code}:
+    parameters:
+      - $ref: '#/parameters/country_code'
+    get:
+      operationId: country_read
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/country'
+      tags:
+        - authentication
+
+  /invitations/{invitation_id}/send:
+    parameters:
+      - name: invitation_id
+        type: string
+        format: uuid
+        in: path
+        required: true
+      - name: language
+        type: string
+        in: query
+        required: false
+        default: "en"
+    get:
+      operationId: invitation_send
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: 'An invitation email was successfully queued for sending.'
+      tags:
+        - authentication
+
+  /organisations:
+    get:
+      operationId: organisation_list
+      parameters:
+        - $ref: '#/parameters/optional_offset'
+        - $ref: '#/parameters/optional_limit'
+        - name: organisation_ids
+          description: An optional list of organisation ids
+          in: query
+          type: array
+          items:
+            type: integer
+          required: false
+          minItems: 1
+          collectionFormat: csv
+          uniqueItems: true
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: ''
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/organisation'
+          headers:
+            X-Total-Count:
+              type: integer
+              description: The total number of results matching the query
+      tags:
+        - authentication
+    post:
+      consumes:
+        - application/json
+      operationId: organisation_create
+      parameters:
+        - in: body
+          name: data
+          schema:
+            $ref: '#/definitions/organisation_create'
+      produces:
+        - application/json
+      responses:
+        '201':
+          description: ''
+          schema:
+            $ref: '#/definitions/organisation'
+      tags:
+        - authentication
+
+  /organisations/{organisation_id}:
+    parameters:
+      - $ref: '#/parameters/organisation_id'
+    delete:
+      operationId: organisation_delete
+      responses:
+        '204':
+          description: ''
+      tags:
+        - authentication
+    get:
+      operationId: organisation_read
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/organisation'
+      tags:
+        - authentication
+    put:
+      consumes:
+        - application/json
+      operationId: organisation_update
+      parameters:
+        - in: body
+          name: data
+          schema:
+            $ref: '#/definitions/organisation_update'
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/organisation'
+      tags:
+        - authentication
+
+  /users:
+    get:
+      operationId: user_list
+      parameters:
+        - $ref: '#/parameters/optional_offset'
+        - $ref: '#/parameters/optional_limit'
+        - name: birth_date
+          description: An optional birth_date range filter
+          in: query
+          required: false
+          type: string
+        - name: country
+          description: An optional country filter
+          in: query
+          required: false
+          type: string
+          minLength: 2
+          maxLength: 2
+        - name: date_joined
+          description: An optional date joined range filter
+          in: query
+          required: false
+          type: string
+        - name: email
+          description: An optional case insensitive email inner match filter
+          in: query
+          required: false
+          type: string
+          minLength: 3
+        - name: email_verified
+          description: An optional email verified filter
+          in: query
+          required: false
+          type: boolean
+        - name: first_name
+          description: An optional case insensitive first name inner match filter
+          in: query
+          required: false
+          type: string
+          minLength: 3
+        - name: gender
+          description: An optional gender filter
+          in: query
+          required: false
+          type: string
+        - name: is_active
+          description: An optional is_active filter
+          in: query
+          required: false
+          type: boolean
+        - name: last_login
+          description: An optional last login range filter
+          in: query
+          required: false
+          type: string
+        - name: last_name
+          description: An optional case insensitive last name inner match filter
+          in: query
+          required: false
+          type: string
+          minLength: 3
+        - name: msisdn
+          description: An optional case insensitive MSISDN inner match filter
+          in: query
+          required: false
+          type: string
+          minLength: 3
+        - name: msisdn_verified
+          description: An optional MSISDN verified filter
+          in: query
+          required: false
+          type: boolean
+        - name: nickname
+          description: An optional case insensitive nickname inner match filter
+          in: query
+          required: false
+          type: string
+          minLength: 3
+        - name: organisation_id
+          description: An optional filter on the organisation id
+          in: query
+          required: false
+          type: integer
+        - name: updated_at
+          description: An optional updated_at range filter
+          in: query
+          required: false
+          type: string
+        - name: username
+          description: An optional case insensitive username inner match filter
+          in: query
+          required: false
+          type: string
+          minLength: 3
+        - name: q
+          description: An optional case insensitive inner match filter across all searchable text fields
+          in: query
+          required: false
+          type: string
+          minLength: 3
+        - name: tfa_enabled
+          description: An optional filter based on whether a user has 2FA enabled or not
+          in: query
+          required: false
+          type: boolean
+        - name: has_organisation
+          description: An optional filter based on whether a user belongs to an organisation or not
+          in: query
+          required: false
+          type: boolean
+        - name: order_by
+          description: Fields and directions to order by, e.g. "-created_at,username". Add "-" in front
+            of a field name to indicate descending order.
+          in: query
+          required: false
+          type: array
+          collectionFormat: csv
+          items:
+            type: string
+          uniqueItems: true
+        - name: user_ids
+          description: An optional list of user ids
+          in: query
+          type: array
+          items:
+            type: string
+            format: uuid
+          required: false
+          minItems: 1
+          collectionFormat: csv
+          uniqueItems: true
+        - name: site_ids
+          description: An optional list of site ids
+          in: query
+          type: array
+          items:
+            type: integer
+          required: false
+          minItems: 1
+          collectionFormat: csv
+          uniqueItems: true
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: ''
+          headers:
+            X-Total-Count:
+              type: integer
+              description: The total number of results matching the query
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/user'
+      tags:
+        - authentication
+
+  /users/{user_id}:
+    parameters:
+      - $ref: '#/parameters/user_id'
+    delete:
+      operationId: user_delete
+      responses:
+        '204':
+          description: ''
+      tags:
+        - authentication
+    get:
+      operationId: user_read
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/user'
+      tags:
+        - authentication
+
+    put:
+      consumes:
+        - application/json
+      operationId: user_update
+      parameters:
+        - in: body
+          name: data
+          schema:
+            $ref: '#/definitions/user_update'
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/user'
+      tags:
+        - authentication
+
+  /invitations/purge_expired:
+    get:
+      operationId: purge_expired_invitations
+      parameters:
+        - $ref: '#/parameters/optional_cutoff_date'
+      responses:
+        200:
+          description: 'Began task to purge invitations.'
+        403:
+          description: 'Forbidden'
+      tags:
+        - authentication
+
+  /request_user_deletion:
+    post:
+      operationId: request_user_deletion
+      consumes:
+        - application/json
+      parameters:
+        - in: body
+          name: data
+          schema:
+            $ref: '#/definitions/request_user_deletion'
+          required: true
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: ''
+      tags:
+        - authentication
+
+#  /openid/authorize/:
+#
+#  /openid/token/:
+#
+#  /openid/userinfo/:
+#
+#  /openid/end-session/:
+#
+#  /openid/jwks/:
+#
+#  /openid/.well-known/openid-configuration:
+
+#  /openid/authorize:
+#    get:
+#      summary: Authenticate a user
+#      description: >
+#        Example:
+#        ```
+#        GET https://localhost:8000/authorize?client_id=<your-client-id>&response_type=code+id_token&scope=openid+email&redirect_uri=<your-redirect-uri>&state=0123456789
+#        ```
+#        This endpoint is compatible with OpenID Connect and also supports the
+#        POST method, in which case the parameters are passed as a form post.
+
+#        See also:
+#          - [OAuth 2.0 Authorization Endpoint](http://tools.ietf.org/html/rfc6749#section-3.1)
+#          - [OIDC Authentication request](http://openid.net/specs/openid-connect-core-1_0.html#AuthRequest)
+#          - [OIDC Successful Authentication response](http://openid.net/specs/openid-connect-core-1_0.html#AuthResponse)
+#          - [OIDC Error Authentication response](http://openid.net/specs/openid-connect-core-1_0.html#AuthError)
+#      tags:
+#        - experimental
+#        - Authentication
+#      operationId: authorize
+#      parameters:
+#        - name: client_id
+#          in: query
+#          description: >
+#            A client ID obtained from the [Dashboard](https://localhost:8000/admin/).
+#          required: true
+#          type: string
+#        - name: response_type
+#          in: query
+#          description: >
+#            The OIDC response type to use for this authentication flow. Valid
+#            choices are `code`, `id_token`, `token`, `token id_token`, `code
+#            id_token` `code token` and `code token id_token`, but a client can
+#            be configured with a more restricted set.
+#          required: true
+#          type: string
+#        - name: scope
+#          in: query
+#          description: >
+#            The space-separated identity claims to request from the end-user.
+#            Always include `openid` as a scope for compatibility with OIDC.
+#          required: true
+#          type: string
+#        - name: redirect_uri
+#          in: query
+#          description: >
+#            The location to redirect to after (un)successful authentication. See
+#            OIDC for the parameters passed in the query string
+#            (`response_mode=query`) or as fragments (`response_mode=fragment`).
+#            This must be one of the registered redirect URLs.
+#          required: true
+#          type: string
+#        - name: state
+#          in: query
+#          description: >
+#            An opaque string that will be passed back to the redirect URL and
+#            therefore can be used to communicate client side state and prevent
+#            CSRF attacks.
+#          required: true
+#          type: string
+#        - name: response_mode
+#          in: query
+#          description: >
+#            Whether to append parameters to the redirect URL in the query string
+#            (`query`) or as fragments (`fragment`). This option usually has a
+#            sensible default for each of the response types.
+#          required: false
+#          type: string
+#        - name: nonce
+#          in: query
+#          description: >
+#            An nonce provided by the client that will be included in any ID Token generated for this session.
+#            Clients should use the nonce to mitigate replay attacks.
+#          required: false
+#          type: string
+#        - name: display
+#          in: query
+#          description: >
+#            The authentication display mode, which can be one of `page`, `popup` or `modal`. Defaults to `page`.
+#          required: false
+#          type: string
+#          default: page
+#        - name: prompt
+#          in: query
+#          description: >
+#            Space-delimited, case sensitive list of ASCII string values that
+#            specifies whether the Authorization Server prompts the End-User for
+#            re-authentication and consent. The supported values are: `none`,
+#            `login`, `consent`. If `consent` the end-user is asked to
+#            (re)confirm what claims they share. Use `none` to check for an
+#            active session.
+#          required: false
+#          type: string
+#          default: login
+#        - name: max_age
+#          in: query
+#          description: >
+#            Specifies the allowable elapsed time in seconds since the last time
+#            the end-user was actively authenticated.
+#          required: false
+#          type: integer
+#          default: 0
+#        - name: ui_locales
+#          in: query
+#          description: >
+#            Specifies the preferred language to use on the authorization page,
+#            as a space-separated list of BCP47 language tags. Ignored at the
+#            moment.
+#          required: false
+#          type: string
+#      responses:
+#        '302':
+#          description: |
+#            A successful or erroneous authentication response.
+#        '303':
+#          description: |
+#            Sign in with page, popup or modal.
+#      externalDocs:
+#        description: OpenID Authorization Endpoint
+#        url: >-
+#          http://openid.net/specs/openid-connect-core-1_0.html#AuthorizationEndpoint
+#  /openid/token:
+#    post:
+#      summary: Obtain an ID Token
+#      description: >
+#        Exchange an authorization code for an ID Token or Access Token.
+
+#        This endpoint supports both `client_secret_post` and
+#        `client_secret_basic` authentication methods, as specified by the
+#        client's `token_endpoint_auth_method`.
+
+#        See also:
+#          - [OIDC Token Endpoint](http://openid.net/specs/openid-connect-core-1_0.html#TokenRequest)
+#          - [OIDC Successful Token response](http://openid.net/specs/openid-connect-core-1_0.html#TokenResponse)
+#          - [OIDC Token Error response](http://openid.net/specs/openid-connect-core-1_0.html#TokenError)
+#      tags:
+#        - experimental
+#        - Authentication
+#      operationId: token
+#      parameters:
+#        - name: Authorization
+#          in: header
+#          description: |
+#            HTTP Basic authorization header.
+#          required: false
+#          type: string
+#        - name: content
+#          in: body
+#          schema:
+#            type: object
+#            properties:
+#              client_id:
+#                description: |
+#                  The registered client ID.
+#                type: string
+#              client_secret:
+#                description: |
+#                  The registered client ID secret.
+#                type: string
+#                format: password
+#              grant_type:
+#                description: |
+#                  The authorization grant type, must be `authorization_code`.
+#                type: string
+#              code:
+#                description: >
+#                  The authorization code previously obtained from the
+#                  Authentication endpoint.
+#                type: string
+#              redirect_uri:
+#                description: >
+#                  The redirect URL that was used previously with the
+#                  Authentication endpoint.
+#                type: string
+#            required:
+#              - client_id
+#      produces:
+#        - application/json
+#      responses:
+#        '200':
+#          $ref: '#/responses/Token'
+#        '400':
+#          $ref: '#/responses/OAuth2Error'
+#        '401':
+#          $ref: '#/responses/OAuth2Error'
+#      externalDocs:
+#        description: OpenID Token Endpoint
+#        url: 'http://openid.net/specs/openid-connect-core-1_0.html#TokenEndpoint'
+
+#  /openid/userinfo:
+#    get:
+#      summary: Retrieve their user profile
+#      tags:
+#        - experimental
+#        - Authentication
+#      description: >
+#        Use this endpoint to retrieve a user's profile in case you've not
+#        already obtained enough details from the ID Token via the Token
+#        Endpoint.
+#         See also:
+#         - [OIDC UserInfo endpoint](http://openid.net/specs/openid-connect-core-1_0.html#UserInfo)
+#      operationId: userInfo
+#      produces:
+#        - application/json
+#      responses:
+#        '200':
+#          $ref: '#/responses/UserInfo'
+#        '401':
+#          $ref: '#/responses/OAuth2Error'
+#        default:
+#          $ref: '#/responses/OAuth2Error'
+#      security:
+#        - oauth_code:
+#            - oidc
+#            - email
+#            - phone
+#            - address
+#            - 'ge:roles'
+#            - 'ge:site'
+#        - oauth_implicit:
+#            - oidc
+#            - email
+#            - phone
+#            - address
+#            - 'ge:roles'
+#            - 'ge:site'
+
+externalDocs:
+  description: Girl Effect Developer Docs
+  url: 'https://girleffect.github.io/core-access-control/'
+
+#responses:
+#  Token:
+#    description: Token response
+#    schema:
+#      $ref: '#/definitions/Token'
+#  UserInfo:
+#    description: UserInfo response
+#    schema:
+#      $ref: '#/definitions/UserInfo'
+#  OAuth2Error:
+#    description: OAuth 2.0 error response
+#    schema:
+#      $ref: '#/definitions/OAuth2Error'
+#  ProblemDetail:
+#    description: Problem Detail error response
+#    schema:
+#      $ref: '#/definitions/ProblemDetail'
+
+

--- a/tests/resources/management_layer.yml
+++ b/tests/resources/management_layer.yml
@@ -1,0 +1,4564 @@
+swagger: '2.0'
+
+# OpenAPI 3.0 makes explicit provision for OpenID Connect. Unfortunately the tooling for OpenAPI 3.0
+# is lagging and not usable at the time of writing (2017/12/08). We have to revisit this at a later stage.
+securityDefinitions:
+  OAuth2:
+    type: oauth2
+    flow: accessCode
+    authorizationUrl: http://localhost:8000/openid/authorize
+    tokenUrl: http:///localhost:8000/openid/token
+    scopes:
+      openid: Grants access to fields required by OpenID
+      profile: Profile fields
+      email: Email
+      address: Addresses
+      phone: Phone numbers
+      roles: Grants access to user roles
+      site: Grants access to site-specific data
+  ApiKeyAuth:
+    type: apiKey
+    in: header
+    name: Authorization
+    description: Workaround for lack of OIDC support. Use "Bearer id_token_goes_here" as the value.
+
+security:
+  - OAuth2: []
+  - ApiKeyAuth: []
+
+schemes:
+  - http
+  - https
+
+host: 'localhost:5000'
+
+info:
+  title: Management Layer API
+  description: >
+    The Management Layer API exposes the functionality that is available to users. Access to this API is based on a
+    user token that must be presented with every request.
+
+
+    The Management Layer ties together the User Data Store, Access Control System and Authentication Service.
+    It performs permission checking and audit logging.
+  version: ''
+
+basePath: /api/v1
+
+parameters:
+  optional_portal_context_header:
+    in: header
+    name: X-GE-Portal-Context
+    type: string
+    required: false
+
+  optional_nocache:
+    description: An optional query parameter to instructing an API call to by pass caches when reading data.
+    in: query
+    name: nocache
+    required: false
+    type: boolean
+    default: false
+
+  optional_limit:
+    description: An optional query parameter to limit the number of results returned.
+    in: query
+    name: limit
+    required: false
+    type: integer
+    minimum: 1
+    maximum: 100
+    default: 20
+    x-admin-on-rest-exclude: true
+
+  optional_offset:
+    description: >-
+      An optional query parameter specifying the offset in the result set to
+      start from.
+    in: query
+    name: offset
+    required: false
+    type: integer
+    default: 0
+    minimum: 0
+    x-admin-on-rest-exclude: true
+
+  optional_domain_filter:
+    description: An optional query parameter to filter by domain_id
+    in: query
+    name: domain_id
+    required: false
+    type: integer
+    x-related-info:
+      rest_resource_name: domains
+      label: name
+
+  optional_invitation_filter:
+    description: An optional query parameter to filter by invitation_id
+    in: query
+    name: invitation_id
+    required: false
+    type: string
+    format: uuid
+
+  optional_parent_filter:
+    description: An optional query parameter to filter by parent_id
+    in: query
+    name: parent_id
+    required: false
+    type: integer
+    x-related-info:
+      rest_resource_name: domains
+      label: name
+
+  optional_role_filter:
+    description: An optional query parameter to filter by role_id
+    in: query
+    name: role_id
+    required: false
+    type: integer
+    x-related-info:
+      rest_resource_name: roles
+      label: label
+
+  optional_user_filter:
+    description: An optional query parameter to filter by user_id
+    in: query
+    name: user_id
+    required: false
+    type: string
+    format: uuid
+
+  optional_cutoff_date:
+    description: An optional cutoff date to purge invites before this date
+    in: query
+    name: cutoff_date
+    required: false
+    type: string
+    format: date
+
+  synchronous_mode:
+    description: Change the mode of the call to synchronous.
+    in: query
+    name: synchronous_mode
+    required: false
+    type: boolean
+    default: false
+
+  domain_id:
+    description: A unique integer value identifying the domain.
+    in: path
+    name: domain_id
+    required: true
+    type: integer
+
+  invitation_id:
+    description: A UUID value identifying the invitation.
+    in: path
+    name: invitation_id
+    required: true
+    type: string
+    format: uuid
+
+  permission_id:
+    description: A unique integer value identifying the permission.
+    in: path
+    name: permission_id
+    required: true
+    type: integer
+
+  resource_id:
+    description: A unique integer value identifying the resource.
+    in: path
+    name: resource_id
+    required: true
+    type: integer
+
+  role_id:
+    description: A unique integer value identifying the role.
+    in: path
+    name: role_id
+    required: true
+    type: integer
+
+  site_id:
+    description: A unique integer value identifying the site.
+    in: path
+    name: site_id
+    required: true
+    type: integer
+
+  user_id:
+    description: A UUID value identifying the user.
+    in: path
+    name: user_id
+    required: true
+    type: string
+    format: uuid
+
+  optional_deleter_id_filter:
+    description: An optional query parameter to filter by deleter_id
+    in: query
+    name: deleter_id
+    required: false
+    type: string
+    format: uuid
+
+  optional_site_filter:
+    description: An optional query parameter to filter by site_id
+    in: query
+    name: site_id
+    required: false
+    type: integer
+    x-related-info:
+      rest_resource_name: sites
+      label: name
+
+  admin_note_id:
+    description: A unique integer value identifying the admin note.
+    in: path
+    name: admin_note_id
+    required: true
+    type: integer
+
+  country_code:
+    description: A unique two-character value identifying the country.
+    in: path
+    name: country_code
+    required: true
+    type: string
+    minLength: 2
+    maxLength: 2
+
+  organisation_id:
+    description: An integer identifying an organisation
+    in: path
+    name: organisation_id
+    required: true
+    type: integer
+
+  client_id:
+    description: A integer identifying the client
+    in: path
+    name: client_id
+    required: true
+    type: integer
+
+definitions:
+  country:
+    type: object
+    properties:
+      code:
+        type: string
+        minLength: 2
+        maxLength: 2
+      name:
+        type: string
+        maxLength: 100
+    required:
+      - code
+      - name
+
+  domain:
+    type: object
+    properties:
+      id:
+        type: integer
+        readOnly: true
+      parent_id:
+        type: integer
+        x-related-info:
+          model: domain
+          label: name
+      name:
+        type: string
+        maxLength: 100
+      description:
+        type: string
+      created_at:
+        type: string
+        format: 'date-time'
+        readOnly: true
+      updated_at:
+        type: string
+        format: 'date-time'
+        readOnly: true
+    required:
+      - id
+      - name
+      - created_at
+      - updated_at
+
+  domain_create:
+    type: object
+    properties:
+      parent_id:
+        type: integer
+        x-related-info:
+          model: domain
+          label: name
+      name:
+        type: string
+        maxLength: 100
+      description:
+        type: string
+    required:
+      - name
+
+  domain_update:
+    type: object
+    properties:
+      parent_id:
+        type: integer
+        x-related-info:
+          model: domain
+          label: name
+      name:
+        type: string
+        maxLength: 100
+      description:
+        type: string
+    minProperties: 1
+
+  role_label:
+    type: string
+    maxLength: 100
+
+  site:
+    type: object
+    properties:
+      id:
+        type: integer
+        readOnly: true
+      client_id:
+        type: integer
+        x-related-info:
+          label: name
+      domain_id:
+        type: integer
+        x-related-info:
+          label: name
+      name:
+        type: string
+        maxLength: 100
+      description:
+        type: string
+      is_active:
+        type: boolean
+      created_at:
+        type: string
+        format: 'date-time'
+        readOnly: true
+      updated_at:
+        type: string
+        format: 'date-time'
+        readOnly: true
+    required:
+      - id
+      - domain_id
+      - name
+      - is_active
+      - created_at
+      - updated_at
+
+  site_create:
+    type: object
+    properties:
+      client_id:
+        type: integer
+        x-related-info:
+          label: name
+      domain_id:
+        type: integer
+        x-related-info:
+          label: name
+      name:
+        type: string
+        maxLength: 100
+      is_active:
+        type: boolean
+      description:
+        type: string
+    required:
+      - domain_id
+      - name
+
+  site_update:
+    type: object
+    properties:
+      client_id:
+        type: integer
+        x-related-info:
+          label: name
+      domain_id:
+        type: integer
+        x-related-info:
+          label: name
+      name:
+        type: string
+        maxLength: 100
+      description:
+        type: string
+      is_active:
+        type: boolean
+    minProperties: 1
+
+  role:
+    type: object
+    properties:
+      id:
+        type: integer
+        readOnly: true
+      label:
+        $ref: '#/definitions/role_label'
+      requires_2fa:
+        type: boolean
+      description:
+        type: string
+      created_at:
+        type: string
+        format: 'date-time'
+        readOnly: true
+      updated_at:
+        type: string
+        format: 'date-time'
+        readOnly: true
+    required:
+      - id
+      - label
+      - requires_2fa
+      - created_at
+      - updated_at
+
+  role_create:
+    type: object
+    properties:
+      label:
+        $ref: '#/definitions/role_label'
+      requires_2fa:
+        type: boolean
+        default: true
+      description:
+        type: string
+    required:
+      - label
+
+  role_update:
+    type: object
+    properties:
+      label:
+        type: string
+        maxLength: 100
+      requires_2fa:
+        type: boolean
+      description:
+        type: string
+    minProperties: 1
+
+  site_role:
+    type: object
+    properties:
+      site_id:
+        type: integer
+        x-related-info:
+          label: name
+      role_id:
+        type: integer
+        x-related-info:
+          label: label
+      grant_implicitly:
+        type: boolean
+      created_at:
+        type: string
+        format: 'date-time'
+        readOnly: true
+      updated_at:
+        type: string
+        format: 'date-time'
+        readOnly: true
+    required:
+      - site_id
+      - role_id
+      - grant_implicitly
+      - created_at
+      - updated_at
+
+  site_role_create:
+    type: object
+    properties:
+      site_id:
+        type: integer
+        x-related-info:
+          label: name
+      role_id:
+        type: integer
+        x-related-info:
+          label: label
+      grant_implicitly:
+        type: boolean
+    required:
+      - site_id
+      - role_id
+
+  site_role_update:
+    type: object
+    properties:
+      grant_implicitly:
+        type: boolean
+    minProperties: 1
+
+  domain_role:
+    type: object
+    properties:
+      domain_id:
+        type: integer
+        x-related-info:
+          label: name
+      role_id:
+        type: integer
+        x-related-info:
+          label: label
+      grant_implicitly:
+        type: boolean
+      created_at:
+        type: string
+        format: 'date-time'
+        readOnly: true
+      updated_at:
+        type: string
+        format: 'date-time'
+        readOnly: true
+    required:
+      - domain_id
+      - role_id
+      - grant_implicitly
+      - created_at
+      - updated_at
+
+  domain_role_create:
+    type: object
+    properties:
+      domain_id:
+        type: integer
+        x-related-info:
+          label: name
+      role_id:
+        type: integer
+        x-related-info:
+          label: label
+      grant_implicitly:
+        type: boolean
+    required:
+      - domain_id
+      - role_id
+
+  domain_role_update:
+    type: object
+    properties:
+      grant_implicitly:
+        type: boolean
+    minProperties: 1
+
+  user_domain_role:
+    type: object
+    properties:
+      user_id:
+        type: string
+        format: uuid
+        x-related-info:
+          label: username
+      domain_id:
+        type: integer
+        x-related-info:
+          label: name
+      role_id:
+        type: integer
+        x-related-info:
+          label: label
+      created_at:
+        type: string
+        format: 'date-time'
+        readOnly: true
+      updated_at:
+        type: string
+        format: 'date-time'
+        readOnly: true
+    required:
+      - user_id
+      - domain_id
+      - role_id
+      - created_at
+      - updated_at
+
+  user_domain_role_create:
+    type: object
+    properties:
+      user_id:
+        type: string
+        format: uuid
+        x-related-info:
+          label: username
+      domain_id:
+        type: integer
+        x-related-info:
+          label: name
+      role_id:
+        type: integer
+        x-related-info:
+          label: label
+    required:
+      - user_id
+      - domain_id
+      - role_id
+
+  user_site_role:
+    type: object
+    properties:
+      user_id:
+        type: string
+        format: uuid
+        x-related-info:
+          label: username
+      site_id:
+        type: integer
+        x-related-info:
+          label: name
+      role_id:
+        type: integer
+        x-related-info:
+          label: label
+      created_at:
+        type: string
+        format: 'date-time'
+        readOnly: true
+      updated_at:
+        type: string
+        format: 'date-time'
+        readOnly: true
+    required:
+      - user_id
+      - site_id
+      - role_id
+      - created_at
+      - updated_at
+
+  user_site_role_create:
+    type: object
+    properties:
+      user_id:
+        type: string
+        format: uuid
+        x-related-info:
+          label: username
+      site_id:
+        type: integer
+        x-related-info:
+          label: name
+      role_id:
+        type: integer
+        x-related-info:
+          label: label
+    required:
+      - user_id
+      - site_id
+      - role_id
+
+  permission:
+    type: object
+    properties:
+      id:
+        type: integer
+        readOnly: true
+      name:
+        type: string
+        maxLength: 50
+      description:
+        type: string
+      created_at:
+        type: string
+        format: 'date-time'
+        readOnly: true
+      updated_at:
+        type: string
+        format: 'date-time'
+        readOnly: true
+    required:
+      - id
+      - name
+      - created_at
+      - updated_at
+
+  permission_create:
+    type: object
+    properties:
+      name:
+        type: string
+        maxLength: 50
+      description:
+        type: string
+    required:
+      - name
+
+  permission_update:
+    type: object
+    properties:
+      name:
+        type: string
+        maxLength: 50
+      description:
+        type: string
+    minProperties: 1
+
+  resource:
+    type: object
+    properties:
+      id:
+        type: integer
+        readOnly: true
+      urn:
+        type: string
+        format: uri
+      description:
+        type: string
+      created_at:
+        type: string
+        format: 'date-time'
+        readOnly: true
+      updated_at:
+        type: string
+        format: 'date-time'
+        readOnly: true
+    required:
+      - id
+      - urn
+      - created_at
+      - updated_at
+
+  resource_create:
+    type: object
+    properties:
+      urn:
+        type: string
+        format: uri
+      description:
+        type: string
+    required:
+      - urn
+
+  resource_update:
+    type: object
+    properties:
+      urn:
+        type: string
+        format: uri
+      description:
+        type: string
+    minProperties: 1
+
+  role_resource_permission:
+    type: object
+    properties:
+      role_id:
+        type: integer
+        x-related-info:
+          label: label
+      resource_id:
+        type: integer
+        x-related-info:
+          label: urn
+      permission_id:
+        type: integer
+        x-related-info:
+          label: name
+      created_at:
+        type: string
+        format: 'date-time'
+        readOnly: true
+      updated_at:
+        type: string
+        format: 'date-time'
+        readOnly: true
+    required:
+      - role_id
+      - resource_id
+      - permission_id
+      - created_at
+      - updated_at
+
+  role_resource_permission_create:
+    type: object
+    properties:
+      role_id:
+        type: integer
+        x-related-info:
+          label: label
+      resource_id:
+        type: integer
+        x-related-info:
+          label: urn
+      permission_id:
+        type: integer
+        x-related-info:
+          label: name
+    required:
+      - role_id
+      - resource_id
+      - permission_id
+
+  invitation:
+    type: object
+    properties:
+      id:
+        type: string
+        format: uuid
+        readOnly: true
+      invitor_id:
+        type: string
+        format: uuid
+        description: The user that created the invitation
+        readOnly: true
+        x-related-info:
+          model: user
+          label: username
+      first_name:
+        type: string
+        maxLength: 100
+      last_name:
+        type: string
+        maxLength: 100
+      email:
+        type: string
+        format: email
+      organisation_id:
+        type: integer
+        x-related-info:
+          model: organisation
+          label: name
+      expires_at:
+        type: string
+        format: 'date-time'
+      created_at:
+        type: string
+        format: 'date-time'
+        readOnly: true
+      updated_at:
+        type: string
+        format: 'date-time'
+        readOnly: true
+    required:
+      - id
+      - invitor_id
+      - first_name
+      - last_name
+      - email
+      - organisation_id
+      - expires_at
+      - created_at
+      - updated_at
+
+  invitation_create:
+    type: object
+    properties:
+      first_name:
+        type: string
+        maxLength: 100
+      last_name:
+        type: string
+        maxLength: 100
+      email:
+        type: string
+        format: email
+      organisation_id:
+        type: integer
+        x-related-info:
+          model: organisation
+          label: name
+      expires_at:
+        type: string
+        format: 'date-time'
+    required:
+      - first_name
+      - last_name
+      - email
+      - organisation_id
+
+  invitation_update:
+    type: object
+    properties:
+      first_name:
+        type: string
+        maxLength: 100
+      last_name:
+        type: string
+        maxLength: 100
+      email:
+        type: string
+        format: email
+      organisation_id:
+        type: integer
+        x-related-info:
+          model: organisation
+          label: name
+      expires_at:
+        type: string
+        format: 'date-time'
+    minProperties: 1
+
+  invitation_domain_role:
+    type: object
+    properties:
+      invitation_id:
+        type: string
+        format: uuid
+        x-related-info:
+          label: email
+      domain_id:
+        type: integer
+        x-related-info:
+          label: name
+      role_id:
+        type: integer
+        x-related-info:
+          label: label
+      created_at:
+        type: string
+        format: 'date-time'
+        readOnly: true
+      updated_at:
+        type: string
+        format: 'date-time'
+        readOnly: true
+    required:
+      - invitation_id
+      - domain_id
+      - role_id
+      - created_at
+      - updated_at
+
+  invitation_domain_role_create:
+    type: object
+    properties:
+      invitation_id:
+        type: string
+        format: uuid
+        x-related-info:
+          label: email
+      domain_id:
+        type: integer
+        x-related-info:
+          label: name
+      role_id:
+        type: integer
+        x-related-info:
+          label: label
+    required:
+      - invitation_id
+      - domain_id
+      - role_id
+
+  invitation_site_role:
+    type: object
+    properties:
+      invitation_id:
+        type: string
+        format: uuid
+        x-related-info:
+          label: email
+      site_id:
+        type: integer
+        x-related-info:
+          label: name
+      role_id:
+        type: integer
+        x-related-info:
+          label: label
+      created_at:
+        type: string
+        format: 'date-time'
+        readOnly: true
+      updated_at:
+        type: string
+        format: 'date-time'
+        readOnly: true
+    required:
+      - invitation_id
+      - site_id
+      - role_id
+      - created_at
+      - updated_at
+
+  invitation_site_role_create:
+    type: object
+    properties:
+      invitation_id:
+        type: string
+        format: uuid
+        x-related-info:
+          label: email
+      site_id:
+        type: integer
+        x-related-info:
+          label: name
+      role_id:
+        type: integer
+        x-related-info:
+          label: label
+    required:
+      - invitation_id
+      - site_id
+      - role_id
+
+  site_role_labels_aggregated:
+    description: 'An object containing a site ID and an aggregated list of all the role labels supported
+      by the site and all the domains in its lineage.'
+    type: object
+    properties:
+      site_id:
+        type: integer
+      roles:
+        type: array
+        items:
+          $ref: '#/definitions/role_label'
+
+  user_site_role_labels_aggregated:
+    description: 'An object containing a user ID, site ID and an aggregated list of all the role labels
+      assigned to the user for the site and all the domains in its lineage.'
+    type: object
+    properties:
+      user_id:
+        type: string
+        format: uuid
+      site_id:
+        type: integer
+      roles:
+        type: array
+        items:
+          $ref: '#/definitions/role_label'
+
+  domain_roles:
+    description: "An object containing the domain roles defined for a given domain and its lineage."
+    type: object
+    properties:
+      domain_id:
+        description: 'The domain for which the request was made.'
+        type: integer
+      roles_map:
+        description: 'A dictionary where the keys are domain ids prefixed with `d:` and the values are lists of role ids.'
+        type: object
+        additionalProperties:
+          description: 'The list of role ids for the domain'
+          type: array
+          items:
+            type: integer
+        example:
+          "d:1": [1]
+          "d:2": [1, 2]
+    required:
+      - domain_id
+      - roles_map
+
+  site_and_domain_roles:
+    description: 'An object containing the site- and domain lineage roles defined for a given site.'
+    type: object
+    properties:
+      site_id:
+        description: 'The site for which the request was made.'
+        type: integer
+      roles_map:
+        description: 'A dictionary where the keys are site and domain ids prefixed with `s:` and `d:`, respectively
+           and the values are lists of role ids.'
+        type: object
+        additionalProperties:
+          description: 'The list of role ids for the site or domain'
+          type: array
+          items:
+            type: integer
+        example:
+          "s:1": [1, 2, 3]
+          "d:1": [1]
+          "d:2": [1, 2]
+    required:
+      - site_id
+      - roles_map
+
+  all_user_roles:
+    description: 'An object containing the effective roles that a user has in any place in the organisational tree.'
+    type: object
+    properties:
+      user_id:
+        type: string
+        format: uuid
+      roles_map:
+        type: object
+        description: 'Domain and site roles'
+        additionalProperties:
+          type: array
+          items:
+            type: integer
+        example:
+          "s:1": [1, 2, 3]
+          "d:1": [1]
+          "d:2": [1, 2]
+    required:
+      - user_id
+      - roles_map
+
+  admin_note:
+    type: object
+    properties:
+      id:
+        type: integer
+        readOnly: true
+      user_id:
+        type: string
+        format: uuid
+        x-related-info:
+          label: username
+      creator_id:
+        type: string
+        format: uuid
+        readOnly: true
+        description: The user making the request will be considered the creator and thus this field is not available
+          when creating admin note.
+        x-related-info:
+          model: user
+          label: username
+      note:
+        type: string
+      created_at:
+        type: string
+        format: 'date-time'
+        readOnly: true
+      updated_at:
+        type: string
+        format: 'date-time'
+        readOnly: true
+    required:
+      - id
+      - user_id
+      - creator_id
+      - note
+      - created_at
+      - updated_at
+
+  admin_note_create:
+    type: object
+    properties:
+      user_id:
+        type: string
+        format: uuid
+        x-related-info:
+          label: username
+      note:
+        type: string
+    required:
+      - user_id
+      - note
+
+  admin_note_update:
+    type: object
+    properties:
+      note:
+        type: string
+    minProperties: 1
+
+  site_data_schema:
+    type: object
+    properties:
+      site_id:
+        type: integer
+        x-related-info:
+          label: name
+      schema:
+        type: object
+      created_at:
+        type: string
+        format: 'date-time'
+        readOnly: true
+      updated_at:
+        type: string
+        format: 'date-time'
+        readOnly: true
+    required:
+      - site_id
+      - schema
+      - created_at
+      - updated_at
+
+  site_data_schema_create:
+    type: object
+    properties:
+      site_id:
+        type: integer
+        x-related-info:
+          label: name
+      schema:
+        type: object
+    required:
+      - site_id
+      - schema
+
+  site_data_schema_update:
+    type: object
+    properties:
+      schema:
+        type: object
+    minProperties: 1
+
+  user_site_data:
+    type: object
+    properties:
+      user_id:
+        type: string
+        format: uuid
+        x-related-info:
+          label: username
+      site_id:
+        type: integer
+        x-related-info:
+          label: name
+      data:
+        type: object
+      created_at:
+        type: string
+        format: date-time
+        readOnly: true
+      updated_at:
+        type: string
+        format: date-time
+        readOnly: true
+    required:
+      - user_id
+      - site_id
+      - data
+      - created_at
+      - updated_at
+
+  user_site_data_create:
+    type: object
+    properties:
+      user_id:
+        type: string
+        format: uuid
+        x-related-info:
+          label: username
+      site_id:
+        type: integer
+        x-related-info:
+          label: name
+      data:
+        type: object
+    required:
+      - user_id
+      - site_id
+      - data
+
+  user_site_data_update:
+    type: object
+    properties:
+      data:
+        type: object
+    minProperties: 1
+
+  deleted_user:
+    type: object
+    properties:
+      id:
+        type: string
+        format: uuid
+      username:
+        type: string
+      email:
+        type: string
+        format: email
+      msisdn:
+        type: string
+      reason:
+        type: string
+      created_at:
+        type: string
+        format: date-time
+        readOnly: true
+      updated_at:
+        type: string
+        format: date-time
+        readOnly: true
+      deleted_at:
+        type: string
+        format: date-time
+      deleter_id:
+        type: string
+        format: uuid
+    required:
+      - id
+      - username
+      - reason
+      - created_at
+      - updated_at
+      - deleter_id
+
+  deleted_user_create:
+    type: object
+    properties:
+      id:
+        type: string
+        format: uuid
+      username:
+        type: string
+      email:
+        type: string
+        format: email
+      msisdn:
+        type: string
+      reason:
+        type: string
+    required:
+      - id
+      - username
+      - reason
+
+  deleted_user_update:
+    type: object
+    properties:
+      username:
+        type: string
+      email:
+        type: string
+        format: email
+      msisdn:
+        type: string
+      reason:
+        type: string
+      deleted_at:
+        type: string
+        format: date-time
+    minProperties: 1
+
+  deleted_user_site:
+    type: object
+    properties:
+      deleted_user_id:
+        type: string
+        format: uuid
+        x-related-info:
+          model: deleted_user
+          label: username
+      site_id:
+        type: integer
+        x-related-info:
+          model: site
+          label: name
+      created_at:
+        type: string
+        format: date-time
+        readOnly: true
+      updated_at:
+        type: string
+        format: date-time
+        readOnly: true
+      deletion_requested_at:
+        type: string
+        format: date-time
+      deletion_requested_via:
+        type: string
+      deletion_confirmed_at:
+        type: string
+        format: date-time
+      deletion_confirmed_via:
+        type: string
+    required:
+      - deleted_user_id
+      - site_id
+      - created_at
+      - updated_at
+
+  deleted_user_site_create:
+    type: object
+    properties:
+      deleted_user_id:
+        type: string
+        format: uuid
+        x-related-info:
+          model: deleted_user
+          label: username
+      site_id:
+        type: integer
+        x-related-info:
+          model: site
+          label: name
+      deletion_requested_at:
+        type: string
+        format: date-time
+      deletion_requested_via:
+        type: string
+      deletion_confirmed_at:
+        type: string
+        format: date-time
+      deletion_confirmed_via:
+        type: string
+    required:
+      - deleted_user_id
+      - site_id
+
+  deleted_user_site_update:
+    type: object
+    properties:
+      deletion_requested_at:
+        type: string
+        format: date-time
+      deletion_requested_via:
+        type: string
+      deletion_confirmed_at:
+        type: string
+        format: date-time
+      deletion_confirmed_via:
+        type: string
+    minProperties: 1
+
+  request_user_deletion:
+    type: object
+    properties:
+      user_id:
+        type: string
+        format: uuid
+      reason:
+        type: string
+    required:
+      - user_id
+      - reason
+
+  client:
+    type: object
+    properties:
+      id:
+        type: integer
+        readOnly: true
+      _post_logout_redirect_uris:
+        description: New-line delimited list of post-logout redirect URIs
+        type: string
+      _redirect_uris:
+        description: New-line delimited list of redirect URIs
+        type: string
+      client_id:
+        description: ''
+        type: string
+        x-related-info:
+          model: null
+      contact_email:
+        description: ''
+        type: string
+      logo:
+        description: ''
+        type: string
+        format: uri
+      name:
+        description: ''
+        type: string
+      require_consent:
+        description: 'If disabled, the Server will NEVER ask the user for consent.'
+        type: boolean
+      response_type:
+        description: ''
+        type: string
+      reuse_consent:
+        description: >-
+          If enabled, the Server will save the user consent given to a
+          specific client, so that user will not be prompted for the same
+          authorization multiple times.
+        type: boolean
+      terms_url:
+        description: External reference to the privacy policy of the client.
+        type: string
+        format: uri
+      website_url:
+        description: ''
+        type: string
+        format: uri
+    required:
+      - id
+      - client_id
+      - response_type
+
+  organisation:
+    type: object
+    properties:
+      id:
+        type: integer
+      name:
+        type: string
+      description:
+        type: string
+      created_at:
+        type: string
+        format: date-time
+        readOnly: true
+      updated_at:
+        type: string
+        format: date-time
+        readOnly: true
+    required:
+      - id
+      - name
+      - description
+      - created_at
+      - updated_at
+
+  organisation_create:
+    type: object
+    properties:
+      name:
+        type: string
+      description:
+        type: string
+    required:
+      - name
+
+  organisation_update:
+    type: object
+    properties:
+      name:
+        type: string
+      description:
+        type: string
+    minProperties: 1
+
+  user:
+    type: object
+    properties:
+      id:
+        description: The UUID of the user
+        type: string
+        format: uuid
+        readOnly: true
+      username:
+        description: >-
+          Required. 150 characters or fewer. Letters, digits and
+          @/./+/-/_ only.
+        type: string
+        readOnly: true
+      first_name:
+        description: ''
+        type: string
+      last_name:
+        description: ''
+        type: string
+      email:
+        description: ''
+        type: string
+        format: email
+      is_active:
+        description: >-
+          Designates whether this user should be treated as active.
+          Deselect this instead of deleting accounts.
+        type: boolean
+      date_joined:
+        description: ''
+        type: string
+        format: date
+        readOnly: true
+      last_login:
+        description: ''
+        type: string
+        format: 'date-time'
+        readOnly: true
+      email_verified:
+        type: boolean
+      msisdn_verified:
+        type: boolean
+      msisdn:
+        type: string
+        maxLength: 15
+      gender:
+        type: string
+      birth_date:
+        type: string
+        format: date
+      avatar:
+        type: string
+        format: uri
+      country_code:
+        type: string
+        minLength: 2
+        maxLength: 2
+        x-related-info:
+          model: country
+          field: code
+          label: name
+      organisation_id:
+        type: integer
+        readOnly: true
+        x-related-info:
+          model: organisation
+          label: name
+      created_at:
+        type: string
+        format: date-time
+        readOnly: true
+      updated_at:
+        type: string
+        format: date-time
+        readOnly: true
+    required:
+      - id
+      - username
+      - is_active
+      - date_joined
+      - created_at
+      - updated_at
+
+  user_update:
+    type: object
+    properties:
+      first_name:
+        description: ''
+        type: string
+      last_name:
+        description: ''
+        type: string
+      email:
+        description: ''
+        type: string
+        format: email
+      is_active:
+        description: >-
+          Designates whether this user should be treated as active.
+          Deselect this instead of deleting accounts.
+        type: boolean
+      email_verified:
+        type: boolean
+      msisdn_verified:
+        type: boolean
+      msisdn:
+        type: string
+        maxLength: 15
+      gender:
+        type: string
+      birth_date:
+        type: string
+        format: date
+      avatar:
+        type: string
+        format: uri
+      country_code:
+        type: string
+        minLength: 2
+        maxLength: 2
+        x-related-info:
+          model: country
+          field: code
+          label: name
+    minProperties: 1
+
+  resource_permission:
+    type: object
+    properties:
+      resource:
+        type: string
+        format: uri
+      permission:
+        type: string
+    required:
+      - resource
+      - permission
+
+  user_permissions_check:
+    type: object
+    properties:
+      operator:
+        type: string
+        enum: [all, any]
+      resource_permissions:
+        type: array
+        items:
+          $ref: '#/definitions/resource_permission'
+      site_id:
+        type: integer
+      domain_id:
+        type: integer
+      nocache:
+        type: boolean
+        default: false
+    required:
+      - operator
+      - resource_permissions
+      # site_id or domain_id is required
+
+  user_permissions_check_response:
+    type: object
+    properties:
+      has_permissions:
+        type: boolean
+    required:
+      - has_permissions
+
+  user_with_roles:
+    description: 'A user with their roles.'
+    type: object
+    properties:
+      id:
+        type: string
+        format: uuid
+      username:
+        type: string
+      roles:
+        type: array
+        items:
+          type: string
+
+  health_info:
+    description: 'Health check response'
+    type: object
+    properties:
+      host:
+        type: string
+      server_timestamp:
+        type: string
+        format: 'date-time'
+      version:
+        type: string
+      access_control_health:
+        type: object
+      user_data_store_health:
+        type: object
+      authentication_service_health:
+        type: object
+
+    required:
+    - host
+    - server_timestamp
+    - version
+    - access_control_health
+    - user_data_store_health
+    - authentication_service_health
+
+  purged_invitations:
+    type: object
+    properties:
+      mode:
+        type: string
+        enum:
+          - asynchronous
+          - synchronous
+      amount:
+        type: integer
+    required:
+      - mode
+
+paths:
+  /healthcheck:
+    get:
+      security: [ ]
+      description: 'Get the status of the service.'
+      operationId: healthcheck
+      produces:
+        - application/json
+      responses:
+        200:
+          description: 'The service is operating normally.'
+          schema:
+            $ref: '#/definitions/health_info'
+
+  /refresh/all:
+    parameters:
+      - $ref: '#/parameters/optional_portal_context_header'
+      - $ref: '#/parameters/optional_nocache'
+    get:
+      description: "Refresh all mapping information"
+      operationId: refresh_all
+      produces:
+        - application/json
+      responses:
+        200:
+          description: "Successfully refreshed all mapping data"
+        403:
+         description: "Forbidden"
+
+  /refresh/clients:
+    parameters:
+      - $ref: '#/parameters/optional_portal_context_header'
+      - $ref: '#/parameters/optional_nocache'
+    get:
+      description: "Refresh OIDC client information"
+      operationId: refresh_clients
+      produces:
+        - application/json
+      responses:
+        200:
+          description: "Successfully refreshed OIDC client data"
+        403:
+         description: "Forbidden"
+
+  /refresh/domains:
+    parameters:
+      - $ref: '#/parameters/optional_portal_context_header'
+      - $ref: '#/parameters/optional_nocache'
+    get:
+      description: "Refresh domain mapping information"
+      operationId: refresh_domains
+      produces:
+        - application/json
+      responses:
+        200:
+          description: "Successfully refreshed domain mapping data"
+        403:
+         description: "Forbidden"
+
+  /refresh/keys:
+    parameters:
+      - $ref: '#/parameters/optional_portal_context_header'
+      - $ref: '#/parameters/optional_nocache'
+    get:
+      description: "Refresh JWKS information"
+      operationId: refresh_keys
+      produces:
+        - application/json
+      responses:
+        200:
+          description: "Successfully refreshed keys data"
+        403:
+         description: "Forbidden"
+
+  /refresh/permissions:
+    parameters:
+      - $ref: '#/parameters/optional_portal_context_header'
+      - $ref: '#/parameters/optional_nocache'
+    get:
+      description: "Refresh permission mapping information"
+      operationId: refresh_permissions
+      produces:
+        - application/json
+      responses:
+        200:
+          description: "Successfully refreshed permission mapping data"
+        403:
+         description: "Forbidden"
+
+  /refresh/resources:
+    parameters:
+      - $ref: '#/parameters/optional_portal_context_header'
+      - $ref: '#/parameters/optional_nocache'
+    get:
+      description: "Refresh resource mapping information"
+      operationId: refresh_resources
+      produces:
+        - application/json
+      responses:
+        200:
+          description: "Successfully refreshed resource mapping data"
+        403:
+         description: "Forbidden"
+
+  /refresh/roles:
+    parameters:
+      - $ref: '#/parameters/optional_portal_context_header'
+      - $ref: '#/parameters/optional_nocache'
+    get:
+      description: "Refresh role mapping information"
+      operationId: refresh_roles
+      produces:
+        - application/json
+      responses:
+        200:
+          description: "Successfully refreshed role mapping data"
+        403:
+         description: "Forbidden"
+
+  /refresh/sites:
+    parameters:
+      - $ref: '#/parameters/optional_portal_context_header'
+      - $ref: '#/parameters/optional_nocache'
+    get:
+      description: "Refresh site mapping information"
+      operationId: refresh_sites
+      produces:
+        - application/json
+      responses:
+        200:
+          description: "Successfully refreshed site mapping data"
+        403:
+         description: "Forbidden"
+
+  /ops/get_sites_under_domain/{domain_id}:
+    parameters:
+      - $ref: '#/parameters/domain_id'
+    get:
+      description: 'Get a list of all sites linked directly or indirectly to the specified domain.'
+      operationId: get_sites_under_domain
+      produces:
+        - application/json
+      responses:
+        200:
+          description: ''
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/site'
+        403:
+          description: 'Forbidden'
+      tags:
+        - operational
+
+  /ops/get_site_from_client_token_id/{client_token_id}:
+    parameters:
+      - $ref: '#/parameters/optional_portal_context_header'
+      - description: A client token id. This is not the primary key of the client table, but rather the client id
+                     that is typically configured along with the client secret.
+        in: path
+        name: client_token_id
+        required: true
+        type: string
+      - $ref: '#/parameters/optional_nocache'
+    get:
+      description: "Get the site associated with the specified client token id"
+      operationId: get_site_from_client_token_id
+      produces:
+        - application/json
+      responses:
+        200:
+          description: ''
+          schema:
+            $ref: '#/definitions/site'
+        403:
+          description: 'Forbidden'
+      tags:
+        - operational
+
+  /ops/user_management_portal_permissions/{user_id}:
+    parameters:
+      - $ref: '#/parameters/optional_portal_context_header'
+      - $ref: '#/parameters/user_id'
+      - $ref: '#/parameters/optional_nocache'
+    get:
+      deprecated: true
+      description: "(DEPRECATED. Use /ops/user_site_permissions instead.) Get a list of all permissions a user has on the Management Portal"
+      operationId: get_user_management_portal_permissions
+      produces:
+        - application/json
+      responses:
+        200:
+          description: ''
+          schema:
+            type: array
+            items:
+              type: string
+            uniqueItems: true
+        403:
+          description: 'Forbidden'
+      tags:
+        - operational
+
+  /ops/user_domain_permissions/{user_id}/{domain_id}:
+    parameters:
+      - $ref: '#/parameters/optional_portal_context_header'
+      - $ref: '#/parameters/user_id'
+      - $ref: '#/parameters/domain_id'
+      - $ref: '#/parameters/optional_nocache'
+    get:
+      description: "Get a list of all resource permissions a user has on the specified domain"
+      operationId: get_user_domain_permissions
+      produces:
+        - application/json
+      responses:
+        200:
+          description: ''
+          schema:
+            type: array
+            items:
+              type: string
+            uniqueItems: true
+        403:
+          description: 'Forbidden'
+      tags:
+        - operational
+
+  /ops/user_site_permissions/{user_id}/{site_id}:
+    parameters:
+      - $ref: '#/parameters/optional_portal_context_header'
+      - $ref: '#/parameters/user_id'
+      - $ref: '#/parameters/site_id'
+      - $ref: '#/parameters/optional_nocache'
+    get:
+      description: "Get a list of all resource permissions a user has on the specified site"
+      operationId: get_user_site_permissions
+      produces:
+        - application/json
+      responses:
+        200:
+          description: ''
+          schema:
+            type: array
+            items:
+              type: string
+            uniqueItems: true
+        403:
+          description: 'Forbidden'
+      tags:
+        - operational
+
+  /ops/site_role_labels_aggregated/{site_id}:
+    parameters:
+      - $ref: '#/parameters/optional_portal_context_header'
+      - $ref: '#/parameters/site_id'
+    get:
+      description: "Get a list of all possible role labels that a user can have from the specified sites perspective."
+      operationId: get_site_role_labels_aggregated
+      produces:
+        - application/json
+      responses:
+        200:
+          description: ''
+          schema:
+            $ref: '#/definitions/site_role_labels_aggregated'
+        403:
+          description: 'Forbidden'
+      tags:
+        - operational
+
+  /ops/user_site_role_labels_aggregated/{user_id}/{site_id}:
+    parameters:
+      - $ref: '#/parameters/optional_portal_context_header'
+      - $ref: '#/parameters/user_id'
+      - $ref: '#/parameters/site_id'
+    get:
+      description: "Get a list of all role labels that the specified user has from the specified sites perspective."
+      operationId: get_user_site_role_labels_aggregated
+      produces:
+        - application/json
+      responses:
+        200:
+          description: ''
+          schema:
+            $ref: '#/definitions/user_site_role_labels_aggregated'
+        403:
+          description: 'Forbidden'
+      tags:
+        - operational
+
+  /ops/domain_roles/{domain_id}:
+    parameters:
+      - $ref: '#/parameters/optional_portal_context_header'
+      - $ref: '#/parameters/domain_id'
+    get:
+      description: "Get the domain and its lineages roles defined for a domain."
+      operationId: get_domain_roles
+      produces:
+        - application/json
+      responses:
+        200:
+          description: ''
+          schema:
+            $ref: '#/definitions/domain_roles'
+        403:
+          description: 'Forbidden'
+      tags:
+        - operational
+
+  /ops/site_and_domain_roles/{site_id}:
+    parameters:
+      - $ref: '#/parameters/optional_portal_context_header'
+      - $ref: '#/parameters/site_id'
+    get:
+      description: 'Get the site- and domain lineage roles defined for a given site.'
+      operationId: get_site_and_domain_roles
+      produces:
+        - application/json
+      responses:
+        200:
+          description: ''
+          schema:
+            $ref: '#/definitions/site_and_domain_roles'
+        403:
+          description: 'Forbidden'
+      tags:
+        - operational
+
+  /ops/all_user_roles/{user_id}:
+    parameters:
+      - $ref: '#/parameters/optional_portal_context_header'
+      - $ref: '#/parameters/user_id'
+    get:
+      description: 'Get the effective roles that a user has at any place in the organisational tree.'
+      operationId: get_all_user_roles
+      produces:
+        - application/json
+      responses:
+        200:
+          description: ''
+          schema:
+            $ref: '#/definitions/all_user_roles'
+        403:
+          description: 'Forbidden'
+        404:
+          description: 'User not found'
+      tags:
+        - operational
+
+  /ops/users_with_roles_for_domain/{domain_id}:
+    parameters:
+      - $ref: '#/parameters/optional_portal_context_header'
+      - $ref: '#/parameters/domain_id'
+    get:
+      description: 'Get a list of Users with their effective roles within the given domain.'
+      operationId: get_users_with_roles_for_domain
+      produces:
+        - application/json
+      responses:
+        200:
+          description: ''
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/user_with_roles'
+        403:
+          description: 'Forbidden'
+        404:
+          description: 'Domain not found'
+      tags:
+        - operational
+
+  /ops/users_with_roles_for_site/{site_id}:
+    parameters:
+      - $ref: '#/parameters/optional_portal_context_header'
+      - $ref: '#/parameters/site_id'
+    get:
+      description: 'Get a list of Users with their effective roles within the given site.'
+      operationId: get_users_with_roles_for_site
+      produces:
+        - application/json
+      responses:
+        200:
+          description: ''
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/user_with_roles'
+        403:
+          description: 'Forbidden'
+        404:
+          description: 'Site not found'
+      tags:
+        - operational
+
+  /ops/user_has_permissions/{user_id}:
+    parameters:
+      - $ref: '#/parameters/optional_portal_context_header'
+      - $ref: '#/parameters/user_id'
+      - in: body
+        name: data
+        schema:
+          $ref: '#/definitions/user_permissions_check'
+    post:
+      description: 'Check of the user has the specified resource permissions'
+      operationId: user_has_permissions
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      responses:
+        200:
+          description: 'True if the user has the permissions, else False'
+          schema:
+            $ref: '#/definitions/user_permissions_check_response'
+        403:
+          description: 'Forbidden'
+        400:
+          description: 'Bad Request'
+        404:
+          description: 'User not found'
+      tags:
+        - operational
+
+  /domains:
+    parameters:
+      - $ref: '#/parameters/optional_portal_context_header'
+    get:
+      operationId: domain_list
+      x-aor-permissions:
+        - 'urn:ge:access_control:domain:read'
+      parameters:
+        - $ref: '#/parameters/optional_offset'
+        - $ref: '#/parameters/optional_limit'
+        - $ref: '#/parameters/optional_parent_filter'
+        - name: domain_ids
+          description: An optional list of domain ids
+          in: query
+          type: array
+          items:
+            type: integer
+          required: false
+          minItems: 1
+          collectionFormat: csv
+          uniqueItems: true
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: ''
+          headers:
+            X-Total-Count:
+              type: integer
+              description: The total number of results matching the query
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/domain'
+      tags:
+        - access_control
+    post:
+      consumes:
+        - application/json
+      operationId: domain_create
+      x-aor-permissions:
+        - 'urn:ge:access_control:domain:create'
+      parameters:
+        - in: body
+          name: data
+          schema:
+            $ref: '#/definitions/domain_create'
+      produces:
+        - application/json
+      responses:
+        '201':
+          description: ''
+          schema:
+            $ref: '#/definitions/domain'
+      tags:
+        - access_control
+
+  /domains/{domain_id}:
+    parameters:
+      - $ref: '#/parameters/optional_portal_context_header'
+      - $ref: '#/parameters/domain_id'
+    delete:
+      operationId: domain_delete
+      x-aor-permissions:
+        - 'urn:ge:access_control:domain:delete'
+      responses:
+        '204':
+          description: ''
+      tags:
+        - access_control
+    get:
+      operationId: domain_read
+      x-aor-permissions:
+        - 'urn:ge:access_control:domain:read'
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/domain'
+      tags:
+        - access_control
+    put:
+      consumes:
+        - application/json
+      operationId: domain_update
+      x-aor-permissions:
+        - 'urn:ge:access_control:domain:update'
+      parameters:
+        - in: body
+          name: data
+          schema:
+            $ref: '#/definitions/domain_update'
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/domain'
+      tags:
+        - access_control
+
+  /domainroles:
+    parameters:
+      - $ref: '#/parameters/optional_portal_context_header'
+    get:
+      operationId: domainrole_list
+      x-aor-permissions:
+        - 'urn:ge:access_control:domainrole:read'
+      parameters:
+        - $ref: '#/parameters/optional_offset'
+        - $ref: '#/parameters/optional_limit'
+        - $ref: '#/parameters/optional_domain_filter'
+        - $ref: '#/parameters/optional_role_filter'
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: ''
+          headers:
+            X-Total-Count:
+              type: integer
+              description: The total number of results matching the query
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/domain_role'
+      tags:
+        - access_control
+    post:
+      consumes:
+        - application/json
+      operationId: domainrole_create
+      x-aor-permissions:
+        - 'urn:ge:access_control:domainrole:create'
+      parameters:
+        - in: body
+          name: data
+          schema:
+            $ref: '#/definitions/domain_role_create'
+      produces:
+        - application/json
+      responses:
+        '201':
+          description: ''
+          schema:
+            $ref: '#/definitions/domain_role'
+      tags:
+        - access_control
+
+  '/domainroles/{domain_id}/{role_id}':
+    parameters:
+      - $ref: '#/parameters/optional_portal_context_header'
+      - $ref: '#/parameters/domain_id'
+      - $ref: '#/parameters/role_id'
+    delete:
+      operationId: domainrole_delete
+      x-aor-permissions:
+        - 'urn:ge:access_control:domainrole:delete'
+      responses:
+        '204':
+          description: ''
+      tags:
+        - access_control
+    get:
+      operationId: domainrole_read
+      x-aor-permissions:
+        - 'urn:ge:access_control:domainrole:read'
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/domain_role'
+      tags:
+        - access_control
+    put:
+      consumes:
+        - application/json
+      operationId: domainrole_update
+      x-aor-permissions:
+        - 'urn:ge:access_control:domainrole:update'
+      parameters:
+        - in: body
+          name: data
+          schema:
+            $ref: '#/definitions/domain_role_update'
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/domain_role'
+      tags:
+        - access_control
+
+  /invitations:
+    parameters:
+      - $ref: '#/parameters/optional_portal_context_header'
+    get:
+      operationId: invitation_list
+      x-aor-permissions:
+        - 'urn:ge:access_control:invitation:read'
+      parameters:
+        - $ref: '#/parameters/optional_offset'
+        - $ref: '#/parameters/optional_limit'
+        - description: Optional filter based on the invitor (the user who created the invitation)
+          name: invitor_id
+          in: query
+          required: false
+          type: string
+          format: uuid
+        - name: invitation_ids
+          description: An optional list of invitation ids
+          in: query
+          type: array
+          items:
+            type: string
+            format: uuid
+          required: false
+          minItems: 1
+          collectionFormat: csv
+          uniqueItems: true
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: ''
+          headers:
+            X-Total-Count:
+              type: integer
+              description: The total number of results matching the query
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/invitation'
+      tags:
+        - access_control
+    post:
+      consumes:
+        - application/json
+      operationId: invitation_create
+      x-aor-permissions:
+        - 'urn:ge:access_control:invitation:create'
+      parameters:
+        - in: body
+          name: data
+          schema:
+            $ref: '#/definitions/invitation_create'
+      produces:
+        - application/json
+      responses:
+        '201':
+          description: ''
+          schema:
+            $ref: '#/definitions/invitation'
+      tags:
+        - access_control
+
+  '/invitations/{invitation_id}':
+    parameters:
+      - $ref: '#/parameters/optional_portal_context_header'
+      - $ref: '#/parameters/invitation_id'
+    delete:
+      operationId: invitation_delete
+      x-aor-permissions:
+        - 'urn:ge:access_control:invitation:delete'
+      responses:
+        '204':
+          description: ''
+      tags:
+        - access_control
+    get:
+      operationId: invitation_read
+      x-aor-permissions:
+        - 'urn:ge:access_control:invitation:read'
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/invitation'
+      tags:
+        - access_control
+    put:
+      consumes:
+        - application/json
+      operationId: invitation_update
+      x-aor-permissions:
+        - 'urn:ge:access_control:invitation:update'
+      parameters:
+        - in: body
+          name: data
+          schema:
+            $ref: '#/definitions/invitation_update'
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/invitation'
+      tags:
+        - access_control
+
+  /invitationdomainroles:
+    parameters:
+      - $ref: '#/parameters/optional_portal_context_header'
+    get:
+      operationId: invitationdomainrole_list
+      x-aor-permissions:
+        - 'urn:ge:access_control:invitationdomainrole:read'
+      parameters:
+        - $ref: '#/parameters/optional_offset'
+        - $ref: '#/parameters/optional_limit'
+        - $ref: '#/parameters/optional_invitation_filter'
+        - $ref: '#/parameters/optional_domain_filter'
+        - $ref: '#/parameters/optional_role_filter'
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: ''
+          headers:
+            X-Total-Count:
+              type: integer
+              description: The total number of results matching the query
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/invitation_domain_role'
+      tags:
+        - access_control
+    post:
+      consumes:
+        - application/json
+      operationId: invitationdomainrole_create
+      x-aor-permissions:
+        - 'urn:ge:access_control:invitationdomainrole:create'
+      parameters:
+        - in: body
+          name: data
+          schema:
+            $ref: '#/definitions/invitation_domain_role_create'
+      produces:
+        - application/json
+      responses:
+        '201':
+          description: ''
+          schema:
+            $ref: '#/definitions/invitation_domain_role'
+      tags:
+        - access_control
+
+  '/invitationdomainroles/{invitation_id}/{domain_id}/{role_id}':
+    parameters:
+      - $ref: '#/parameters/optional_portal_context_header'
+      - $ref: '#/parameters/invitation_id'
+      - $ref: '#/parameters/domain_id'
+      - $ref: '#/parameters/role_id'
+    delete:
+      operationId: invitationdomainrole_delete
+      x-aor-permissions:
+        - 'urn:ge:access_control:invitationdomainrole:delete'
+      produces:
+        - application/json
+      responses:
+        '204':
+          description: ''
+      tags:
+        - access_control
+    get:
+      operationId: invitationdomainrole_read
+      x-aor-permissions:
+        - 'urn:ge:access_control:invitationdomainrole:read'
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/invitation_domain_role'
+      tags:
+        - access_control
+
+  /invitationsiteroles:
+    parameters:
+      - $ref: '#/parameters/optional_portal_context_header'
+    get:
+      operationId: invitationsiterole_list
+      x-aor-permissions:
+        - 'urn:ge:access_control:invitationsiterole:read'
+      parameters:
+        - $ref: '#/parameters/optional_offset'
+        - $ref: '#/parameters/optional_limit'
+        - $ref: '#/parameters/optional_invitation_filter'
+        - $ref: '#/parameters/optional_site_filter'
+        - $ref: '#/parameters/optional_role_filter'
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: ''
+          headers:
+            X-Total-Count:
+              type: integer
+              description: The total number of results matching the query
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/invitation_site_role'
+      tags:
+        - access_control
+    post:
+      consumes:
+        - application/json
+      operationId: invitationsiterole_create
+      x-aor-permissions:
+        - 'urn:ge:access_control:invitationsiterole:create'
+      parameters:
+        - in: body
+          name: data
+          schema:
+            $ref: '#/definitions/invitation_site_role_create'
+      produces:
+        - application/json
+      responses:
+        '201':
+          description: ''
+          schema:
+            $ref: '#/definitions/invitation_site_role'
+      tags:
+        - access_control
+
+  '/invitationsiteroles/{invitation_id}/{site_id}/{role_id}':
+    parameters:
+      - $ref: '#/parameters/optional_portal_context_header'
+      - $ref: '#/parameters/invitation_id'
+      - $ref: '#/parameters/site_id'
+      - $ref: '#/parameters/role_id'
+    delete:
+      operationId: invitationsiterole_delete
+      x-aor-permissions:
+        - 'urn:ge:access_control:invitationsiterole:delete'
+      responses:
+        '204':
+          description: ''
+      tags:
+        - access_control
+    get:
+      operationId: invitationsiterole_read
+      x-aor-permissions:
+        - 'urn:ge:access_control:invitationsiterole:read'
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/invitation_site_role'
+      tags:
+        - access_control
+
+  /permissions:
+    parameters:
+      - $ref: '#/parameters/optional_portal_context_header'
+    get:
+      operationId: permission_list
+      x-aor-permissions:
+        - 'urn:ge:access_control:permission:read'
+      parameters:
+        - $ref: '#/parameters/optional_offset'
+        - $ref: '#/parameters/optional_limit'
+        - name: permission_ids
+          description: An optional list of permission ids
+          in: query
+          type: array
+          items:
+            type: integer
+          required: false
+          minItems: 1
+          collectionFormat: csv
+          uniqueItems: true
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: ''
+          headers:
+            X-Total-Count:
+              type: integer
+              description: The total number of results matching the query
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/permission'
+      tags:
+        - access_control
+    post:
+      consumes:
+        - application/json
+      operationId: permission_create
+      x-aor-permissions:
+        - 'urn:ge:access_control:permission:create'
+      parameters:
+        - in: body
+          name: data
+          schema:
+            $ref: '#/definitions/permission_create'
+      produces:
+        - application/json
+      responses:
+        '201':
+          description: ''
+          schema:
+            $ref: '#/definitions/permission'
+      tags:
+        - access_control
+
+  '/permissions/{permission_id}':
+    parameters:
+      - $ref: '#/parameters/optional_portal_context_header'
+      - $ref: '#/parameters/permission_id'
+    delete:
+      operationId: permission_delete
+      x-aor-permissions:
+        - 'urn:ge:access_control:permission:delete'
+      responses:
+        '204':
+          description: ''
+      tags:
+        - access_control
+    get:
+      operationId: permission_read
+      x-aor-permissions:
+        - 'urn:ge:access_control:permission:read'
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/permission'
+      tags:
+        - access_control
+    put:
+      consumes:
+        - application/json
+      operationId: permission_update
+      x-aor-permissions:
+        - 'urn:ge:access_control:permission:update'
+      parameters:
+        - in: body
+          name: data
+          schema:
+            $ref: '#/definitions/permission_update'
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/permission'
+      tags:
+        - access_control
+
+  /resources:
+    parameters:
+      - $ref: '#/parameters/optional_portal_context_header'
+    get:
+      operationId: resource_list
+      x-aor-permissions:
+        - 'urn:ge:access_control:resource:read'
+      parameters:
+        - $ref: '#/parameters/optional_offset'
+        - $ref: '#/parameters/optional_limit'
+        - description: An optional URN prefix filter
+          name: prefix
+          in: query
+          required: false
+          type: string
+        - name: resource_ids
+          description: An optional list of resource ids
+          in: query
+          type: array
+          items:
+            type: integer
+          required: false
+          minItems: 1
+          collectionFormat: csv
+          uniqueItems: true
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: ''
+          headers:
+            X-Total-Count:
+              type: integer
+              description: The total number of results matching the query
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/resource'
+      tags:
+        - access_control
+    post:
+      consumes:
+        - application/json
+      operationId: resource_create
+      x-aor-permissions:
+        - 'urn:ge:access_control:resource:create'
+      parameters:
+        - in: body
+          name: data
+          schema:
+            $ref: '#/definitions/resource_create'
+      produces:
+        - application/json
+      responses:
+        '201':
+          description: ''
+          schema:
+            $ref: '#/definitions/resource'
+      tags:
+        - access_control
+
+  '/resources/{resource_id}':
+    parameters:
+      - $ref: '#/parameters/optional_portal_context_header'
+      - $ref: '#/parameters/resource_id'
+    delete:
+      operationId: resource_delete
+      x-aor-permissions:
+        - 'urn:ge:access_control:resource:delete'
+      responses:
+        '204':
+          description: ''
+      tags:
+        - access_control
+    get:
+      operationId: resource_read
+      x-aor-permissions:
+        - 'urn:ge:access_control:resource:read'
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/resource'
+      tags:
+        - access_control
+    put:
+      consumes:
+        - application/json
+      operationId: resource_update
+      x-aor-permissions:
+        - 'urn:ge:access_control:resource:update'
+      parameters:
+        - in: body
+          name: data
+          schema:
+            $ref: '#/definitions/resource_update'
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/resource'
+      tags:
+        - access_control
+
+  /roles:
+    parameters:
+      - $ref: '#/parameters/optional_portal_context_header'
+    get:
+      operationId: role_list
+      x-aor-permissions:
+        - 'urn:ge:access_control:role:read'
+      parameters:
+        - $ref: '#/parameters/optional_offset'
+        - $ref: '#/parameters/optional_limit'
+        - name: role_ids
+          description: An optional list of role ids
+          in: query
+          type: array
+          items:
+            type: integer
+          required: false
+          minItems: 1
+          collectionFormat: csv
+          uniqueItems: true
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: ''
+          headers:
+            X-Total-Count:
+              type: integer
+              description: The total number of results matching the query
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/role'
+      tags:
+        - access_control
+    post:
+      consumes:
+        - application/json
+      operationId: role_create
+      x-aor-permissions:
+        - 'urn:ge:access_control:role:create'
+      parameters:
+        - in: body
+          name: data
+          schema:
+            $ref: '#/definitions/role_create'
+      produces:
+        - application/json
+      responses:
+        '201':
+          description: ''
+          schema:
+            $ref: '#/definitions/role'
+      tags:
+        - access_control
+
+  '/roles/{role_id}':
+    parameters:
+      - $ref: '#/parameters/role_id'
+    delete:
+      operationId: role_delete
+      x-aor-permissions:
+        - 'urn:ge:access_control:role:delete'
+      responses:
+        '204':
+          description: ''
+      tags:
+        - access_control
+    get:
+      operationId: role_read
+      x-aor-permissions:
+        - 'urn:ge:access_control:role:read'
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/role'
+      tags:
+        - access_control
+    put:
+      consumes:
+        - application/json
+      operationId: role_update
+      x-aor-permissions:
+        - 'urn:ge:access_control:role:update'
+      parameters:
+        - in: body
+          name: data
+          schema:
+            $ref: '#/definitions/role_update'
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/role'
+      tags:
+        - access_control
+
+  /roleresourcepermissions:
+    parameters:
+      - $ref: '#/parameters/optional_portal_context_header'
+    get:
+      operationId: roleresourcepermission_list
+      x-aor-permissions:
+        - 'urn:ge:access_control:roleresourcepermission:read'
+      parameters:
+        - $ref: '#/parameters/optional_offset'
+        - $ref: '#/parameters/optional_limit'
+        - $ref: '#/parameters/optional_role_filter'
+        - description: An optional resource filter
+          name: resource_id
+          in: query
+          required: false
+          type: integer
+        - description: An optional permission filter
+          name: permission_id
+          in: query
+          required: false
+          type: integer
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: ''
+          headers:
+            X-Total-Count:
+              type: integer
+              description: The total number of results matching the query
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/role_resource_permission'
+      tags:
+        - access_control
+    post:
+      consumes:
+        - application/json
+      operationId: roleresourcepermission_create
+      x-aor-permissions:
+        - 'urn:ge:access_control:roleresourcepermission:create'
+      parameters:
+        - in: body
+          name: data
+          schema:
+            $ref: '#/definitions/role_resource_permission_create'
+      produces:
+        - application/json
+      responses:
+        '201':
+          description: ''
+          schema:
+            $ref: '#/definitions/role_resource_permission'
+      tags:
+        - access_control
+
+  /roleresourcepermissions/{role_id}/{resource_id}/{permission_id}:
+    parameters:
+      - $ref: '#/parameters/optional_portal_context_header'
+      - $ref: '#/parameters/role_id'
+      - $ref: '#/parameters/resource_id'
+      - $ref: '#/parameters/permission_id'
+    delete:
+      operationId: roleresourcepermission_delete
+      x-aor-permissions:
+        - 'urn:ge:access_control:roleresourcepermission:delete'
+      responses:
+        '204':
+          description: ''
+      tags:
+        - access_control
+    get:
+      operationId: roleresourcepermission_read
+      x-aor-permissions:
+        - 'urn:ge:access_control:roleresourcepermission:update'
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/role_resource_permission'
+      tags:
+        - access_control
+
+  /sites:
+    parameters:
+      - $ref: '#/parameters/optional_portal_context_header'
+    get:
+      operationId: site_list
+      x-aor-permissions:
+        - 'urn:ge:access_control:site:read'
+      parameters:
+        - $ref: '#/parameters/optional_offset'
+        - $ref: '#/parameters/optional_limit'
+        - name: site_ids
+          description: An optional list of site ids
+          in: query
+          type: array
+          items:
+            type: integer
+          required: false
+          minItems: 1
+          collectionFormat: csv
+          uniqueItems: true
+        - name: client_id
+          description: An optional client id to filter on
+          in: query
+          type: integer
+          required: false
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: ''
+          headers:
+            X-Total-Count:
+              type: integer
+              description: The total number of results matching the query
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/site'
+      tags:
+        - access_control
+    post:
+      consumes:
+        - application/json
+      operationId: site_create
+      x-aor-permissions:
+        - 'urn:ge:access_control:site:create'
+      parameters:
+        - in: body
+          name: data
+          schema:
+            $ref: '#/definitions/site_create'
+      produces:
+        - application/json
+      responses:
+        '201':
+          description: ''
+          schema:
+            $ref: '#/definitions/site'
+      tags:
+        - access_control
+
+  /sites/{site_id}:
+    parameters:
+      - $ref: '#/parameters/optional_portal_context_header'
+      - $ref: '#/parameters/site_id'
+    delete:
+      operationId: site_delete
+      x-aor-permissions:
+        - 'urn:ge:access_control:site:delete'
+      responses:
+        '204':
+          description: ''
+      tags:
+        - access_control
+    get:
+      operationId: site_read
+      x-aor-permissions:
+        - 'urn:ge:access_control:site:read'
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/site'
+      tags:
+        - access_control
+    put:
+      consumes:
+        - application/json
+      operationId: site_update
+      x-aor-permissions:
+        - 'urn:ge:access_control:site:update'
+      parameters:
+        - in: body
+          name: data
+          schema:
+            $ref: '#/definitions/site_update'
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/site'
+      tags:
+        - access_control
+
+  /siteroles:
+    parameters:
+      - $ref: '#/parameters/optional_portal_context_header'
+    get:
+      operationId: siterole_list
+      x-aor-permissions:
+        - 'urn:ge:access_control:siterole:read'
+      parameters:
+        - $ref: '#/parameters/optional_offset'
+        - $ref: '#/parameters/optional_limit'
+        - $ref: '#/parameters/optional_site_filter'
+        - $ref: '#/parameters/optional_role_filter'
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: ''
+          headers:
+            X-Total-Count:
+              type: integer
+              description: The total number of results matching the query
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/site_role'
+      tags:
+        - access_control
+    post:
+      consumes:
+        - application/json
+      operationId: siterole_create
+      x-aor-permissions:
+        - 'urn:ge:access_control:siterole:create'
+      parameters:
+        - in: body
+          name: data
+          schema:
+            $ref: '#/definitions/site_role_create'
+      produces:
+        - application/json
+      responses:
+        '201':
+          description: ''
+          schema:
+            $ref: '#/definitions/site_role'
+      tags:
+        - access_control
+
+  '/siteroles/{site_id}/{role_id}':
+    parameters:
+      - $ref: '#/parameters/optional_portal_context_header'
+      - $ref: '#/parameters/site_id'
+      - $ref: '#/parameters/role_id'
+    delete:
+      operationId: siterole_delete
+      x-aor-permissions:
+        - 'urn:ge:access_control:siterole:delete'
+      responses:
+        '204':
+          description: ''
+      tags:
+        - access_control
+    get:
+      operationId: siterole_read
+      x-aor-permissions:
+        - 'urn:ge:access_control:siterole:read'
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/site_role'
+      tags:
+        - access_control
+    put:
+      consumes:
+        - application/json
+      operationId: siterole_update
+      x-aor-permissions:
+        - 'urn:ge:access_control:siterole:update'
+      parameters:
+        - in: body
+          name: data
+          schema:
+            $ref: '#/definitions/site_role_update'
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/site_role'
+      tags:
+        - access_control
+
+  /userdomainroles:
+    parameters:
+      - $ref: '#/parameters/optional_portal_context_header'
+    get:
+      operationId: userdomainrole_list
+      x-aor-permissions:
+        - 'urn:ge:access_control:userdomainrole:read'
+      parameters:
+        - $ref: '#/parameters/optional_offset'
+        - $ref: '#/parameters/optional_limit'
+        - $ref: '#/parameters/optional_user_filter'
+        - $ref: '#/parameters/optional_domain_filter'
+        - $ref: '#/parameters/optional_role_filter'
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: ''
+          headers:
+            X-Total-Count:
+              type: integer
+              description: The total number of results matching the query
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/user_domain_role'
+      tags:
+        - access_control
+    post:
+      consumes:
+        - application/json
+      operationId: userdomainrole_create
+      x-aor-permissions:
+        - 'urn:ge:access_control:userdomainrole:create'
+      parameters:
+        - in: body
+          name: data
+          schema:
+            $ref: '#/definitions/user_domain_role_create'
+      produces:
+        - application/json
+      responses:
+        '201':
+          description: ''
+          schema:
+            $ref: '#/definitions/user_domain_role'
+      tags:
+        - access_control
+
+  '/userdomainroles/{user_id}/{domain_id}/{role_id}':
+    parameters:
+      - $ref: '#/parameters/optional_portal_context_header'
+      - $ref: '#/parameters/user_id'
+      - $ref: '#/parameters/domain_id'
+      - $ref: '#/parameters/role_id'
+    delete:
+      operationId: userdomainrole_delete
+      x-aor-permissions:
+        - 'urn:ge:access_control:userdomainrole:delete'
+      responses:
+        '204':
+          description: ''
+      tags:
+        - access_control
+    get:
+      operationId: userdomainrole_read
+      x-aor-permissions:
+        - 'urn:ge:access_control:userdomainrole:read'
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/user_domain_role'
+      tags:
+        - access_control
+
+  /usersiteroles:
+    parameters:
+      - $ref: '#/parameters/optional_portal_context_header'
+    get:
+      operationId: usersiterole_list
+      x-aor-permissions:
+        - 'urn:ge:access_control:usersiterole:read'
+      parameters:
+        - $ref: '#/parameters/optional_offset'
+        - $ref: '#/parameters/optional_limit'
+        - $ref: '#/parameters/optional_user_filter'
+        - $ref: '#/parameters/optional_site_filter'
+        - $ref: '#/parameters/optional_role_filter'
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: ''
+          headers:
+            X-Total-Count:
+              type: integer
+              description: The total number of results matching the query
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/user_site_role'
+      tags:
+        - access_control
+    post:
+      consumes:
+        - application/json
+      operationId: usersiterole_create
+      x-aor-permissions:
+        - 'urn:ge:access_control:usersiterole:create'
+      parameters:
+        - in: body
+          name: data
+          schema:
+            $ref: '#/definitions/user_site_role_create'
+      produces:
+        - application/json
+      responses:
+        '201':
+          description: ''
+          schema:
+            $ref: '#/definitions/user_site_role'
+      tags:
+        - access_control
+
+  /usersiteroles/{user_id}/{site_id}/{role_id}:
+    parameters:
+      - $ref: '#/parameters/optional_portal_context_header'
+      - $ref: '#/parameters/user_id'
+      - $ref: '#/parameters/site_id'
+      - $ref: '#/parameters/role_id'
+    delete:
+      operationId: usersiterole_delete
+      x-aor-permissions:
+        - 'urn:ge:access_control:usersiterole:delete'
+      responses:
+        '204':
+          description: ''
+      tags:
+        - access_control
+    get:
+      operationId: usersiterole_read
+      x-aor-permissions:
+        - 'urn:ge:access_control:usersiterole:read'
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/user_site_role'
+      tags:
+        - access_control
+
+  /usersitedata:
+    parameters:
+      - $ref: '#/parameters/optional_portal_context_header'
+    get:
+      operationId: usersitedata_list
+      x-aor-permissions:
+        - 'urn:ge:user_data:usersitedata:read'
+      parameters:
+        - $ref: '#/parameters/optional_offset'
+        - $ref: '#/parameters/optional_limit'
+        - $ref: '#/parameters/optional_user_filter'
+        - $ref: '#/parameters/optional_site_filter'
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: ''
+          headers:
+            X-Total-Count:
+              type: integer
+              description: The total number of results matching the query
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/user_site_data'
+      tags:
+        - user_data
+    post:
+      operationId: usersitedata_create
+      x-aor-permissions:
+        - 'urn:ge:user_data:usersitedata:create'
+      parameters:
+        - in: body
+          name: data
+          schema:
+            $ref: '#/definitions/user_site_data_create'
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      responses:
+        '201':
+          description: ''
+          schema:
+            $ref: '#/definitions/user_site_data'
+      tags:
+        - user_data
+
+  /usersitedata/{user_id}/{site_id}:
+    parameters:
+      - $ref: '#/parameters/optional_portal_context_header'
+      - $ref: '#/parameters/user_id'
+      - $ref: '#/parameters/site_id'
+    delete:
+      operationId: usersitedata_delete
+      x-aor-permissions:
+        - 'urn:ge:user_data:usersitedata:delete'
+      responses:
+        '204':
+          description: ''
+      tags:
+        - user_data
+    get:
+      operationId: usersitedata_read
+      x-aor-permissions:
+        - 'urn:ge:user_data:usersitedata:read'
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/user_site_data'
+      tags:
+        - user_data
+    put:
+      operationId: usersitedata_update
+      x-aor-permissions:
+        - 'urn:ge:user_data:usersitedata:update'
+      parameters:
+        - in: body
+          name: data
+          schema:
+            $ref: '#/definitions/user_site_data_update'
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/user_site_data'
+      tags:
+        - user_data
+
+  /deletedusers:
+    get:
+      operationId: deleteduser_list
+      x-aor-permissions:
+        - 'urn:ge:user_data:deleteduser:read'
+      parameters:
+        - $ref: '#/parameters/optional_offset'
+        - $ref: '#/parameters/optional_limit'
+        - $ref: '#/parameters/optional_deleter_id_filter'
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: ''
+          headers:
+            X-Total-Count:
+                type: integer
+                description: The total number of results matching the query
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/deleted_user'
+      tags:
+        - user_data
+    post:
+      operationId: deleteduser_create
+      x-aor-permissions:
+        - 'urn:ge:user_data:deleteduser:create'
+      parameters:
+        - in: body
+          name: data
+          schema:
+            $ref: '#/definitions/deleted_user_create'
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      responses:
+        '201':
+          description: ''
+          schema:
+            $ref: '#/definitions/deleted_user'
+      tags:
+        - user_data
+
+  /deletedusers/{user_id}:
+    parameters:
+      - $ref: '#/parameters/user_id'
+    delete:
+      operationId: deleteduser_delete
+      x-aor-permissions:
+        - 'urn:ge:user_data:deleteduser:delete'
+      responses:
+        '204':
+          description: ''
+      tags:
+        - user_data
+    get:
+      operationId: deleteduser_read
+      x-aor-permissions:
+        - 'urn:ge:user_data:deleteduser:read'
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/deleted_user'
+      tags:
+        - user_data
+    put:
+      operationId: deleteduser_update
+      x-aor-permissions:
+        - 'urn:ge:user_data:deleteduser:update'
+      parameters:
+        - in: body
+          name: data
+          schema:
+            $ref: '#/definitions/deleted_user_update'
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/deleted_user'
+      tags:
+        - user_data
+
+  /deletedusersites:
+    get:
+      operationId: deletedusersite_list
+      x-aor-permissions:
+        - 'urn:ge:user_data:deletedusersite:read'
+      parameters:
+        - $ref: '#/parameters/optional_offset'
+        - $ref: '#/parameters/optional_limit'
+        - $ref: '#/parameters/optional_user_filter'
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: ''
+          headers:
+            X-Total-Count:
+                type: integer
+                description: The total number of results matching the query
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/deleted_user_site'
+      tags:
+        - user_data
+    post:
+      operationId: deletedusersite_create
+      x-aor-permissions:
+        - 'urn:ge:user_data:deletedusersite:create'
+      parameters:
+        - in: body
+          name: data
+          schema:
+            $ref: '#/definitions/deleted_user_site_create'
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      responses:
+        '201':
+          description: ''
+          schema:
+            $ref: '#/definitions/deleted_user_site'
+      tags:
+        - user_data
+
+  /deletedusersites/{user_id}/{site_id}:
+    parameters:
+      - $ref: '#/parameters/user_id'
+      - $ref: '#/parameters/site_id'
+    delete:
+      operationId: deletedusersite_delete
+      x-aor-permissions:
+        - 'urn:ge:user_data:deletedusersite:delete'
+      responses:
+        '204':
+          description: ''
+      tags:
+        - user_data
+    get:
+      operationId: deletedusersite_read
+      x-aor-permissions:
+        - 'urn:ge:user_data:deletedusersite:read'
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/deleted_user_site'
+      tags:
+        - user_data
+    put:
+      operationId: deletedusersite_update
+      x-aor-permissions:
+        - 'urn:ge:user_data:deletedusersite:update'
+      parameters:
+        - in: body
+          name: data
+          schema:
+            $ref: '#/definitions/deleted_user_site_update'
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/deleted_user_site'
+      tags:
+        - user_data
+
+  /adminnotes:
+    parameters:
+      - $ref: '#/parameters/optional_portal_context_header'
+    get:
+      operationId: adminnote_list
+      x-aor-permissions:
+        - 'urn:ge:user_data:adminnote:read'
+      parameters:
+        - $ref: '#/parameters/optional_offset'
+        - $ref: '#/parameters/optional_limit'
+        - $ref: '#/parameters/optional_user_filter'
+        - description: An optional query parameter to filter by creator (a user_id)
+          in: query
+          name: creator_id
+          required: false
+          type: string
+          format: uuid
+        - name: admin_note_ids
+          description: An optional list of adminnote ids
+          in: query
+          type: array
+          items:
+            type: integer
+          required: false
+          minItems: 1
+          collectionFormat: csv
+          uniqueItems: true
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: ''
+          headers:
+            X-Total-Count:
+              type: integer
+              description: The total number of results matching the query
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/admin_note'
+        403:
+          description: 'Forbidden'
+      tags:
+        - user_data
+    post:
+      consumes:
+        - application/json
+      operationId: adminnote_create
+      x-aor-permissions:
+        - 'urn:ge:user_data:adminnote:create'
+      parameters:
+        - in: body
+          name: data
+          schema:
+            $ref: '#/definitions/admin_note_create'
+      produces:
+        - application/json
+      responses:
+        '201':
+          description: ''
+          schema:
+            $ref: '#/definitions/admin_note'
+        403:
+          description: 'Forbidden'
+      tags:
+        - user_data
+
+  /adminnotes/{admin_note_id}:
+    parameters:
+      - $ref: '#/parameters/optional_portal_context_header'
+      - $ref: '#/parameters/admin_note_id'
+    delete:
+      operationId: adminnote_delete
+      x-aor-permissions:
+        - 'urn:ge:user_data:adminnote:delete'
+      responses:
+        '204':
+          description: 'Deleted'
+        403:
+          description: 'Forbidden'
+      tags:
+        - user_data
+    get:
+      operationId: adminnote_read
+      x-aor-permissions:
+        - 'urn:ge:user_data:adminnote:read'
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/admin_note'
+        403:
+          description: 'Forbidden'
+      tags:
+        - user_data
+    put:
+      consumes:
+        - application/json
+      operationId: adminnote_update
+      x-aor-permissions:
+        - 'urn:ge:user_data:adminnote:update'
+      parameters:
+        - in: body
+          name: data
+          schema:
+            $ref: '#/definitions/admin_note_update'
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/admin_note'
+        403:
+          description: 'Forbidden'
+      tags:
+        - user_data
+
+  /sitedataschemas:
+    parameters:
+      - $ref: '#/parameters/optional_portal_context_header'
+    get:
+      operationId: sitedataschema_list
+      x-aor-permissions:
+        - 'urn:ge:user_data:sitedataschema:read'
+      parameters:
+        - $ref: '#/parameters/optional_offset'
+        - $ref: '#/parameters/optional_limit'
+        - name: site_ids
+          description: An optional list of site ids
+          in: query
+          type: array
+          items:
+            type: integer
+          required: false
+          minItems: 1
+          collectionFormat: csv
+          uniqueItems: true
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: ''
+          headers:
+            X-Total-Count:
+              type: integer
+              description: The total number of results matching the query
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/site_data_schema'
+      tags:
+        - user_data
+    post:
+      consumes:
+        - application/json
+      operationId: sitedataschema_create
+      x-aor-permissions:
+        - 'urn:ge:user_data:sitedataschema:create'
+      parameters:
+        - in: body
+          name: data
+          schema:
+            $ref: '#/definitions/site_data_schema_create'
+      produces:
+        - application/json
+      responses:
+        '201':
+          description: ''
+          schema:
+            $ref: '#/definitions/site_data_schema'
+      tags:
+        - user_data
+
+  /sitedataschemas/{site_id}:
+    parameters:
+      - $ref: '#/parameters/optional_portal_context_header'
+      - $ref: '#/parameters/site_id'
+    delete:
+      operationId: sitedataschema_delete
+      x-aor-permissions:
+        - 'urn:ge:user_data:sitedataschema:delete'
+      responses:
+        '204':
+          description: ''
+      tags:
+        - user_data
+    get:
+      operationId: sitedataschema_read
+      x-aor-permissions:
+        - 'urn:ge:user_data:sitedataschema:read'
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/site_data_schema'
+      tags:
+        - user_data
+    put:
+      operationId: sitedataschema_update
+      x-aor-permissions:
+        - 'urn:ge:user_data:sitedataschema:update'
+      parameters:
+        - in: body
+          name: data
+          schema:
+            $ref: '#/definitions/site_data_schema_update'
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/site_data_schema'
+      tags:
+        - user_data
+
+  /clients:
+    parameters:
+      - $ref: '#/parameters/optional_portal_context_header'
+    get:
+      operationId: client_list
+      x-aor-permissions:
+        - 'urn:ge:identity_provider:oidc_provider:client:read'
+      parameters:
+        - $ref: '#/parameters/optional_offset'
+        - $ref: '#/parameters/optional_limit'
+        - name: client_ids
+          description: An optional list of client ids
+          in: query
+          type: array
+          items:
+            type: integer
+          required: false
+          minItems: 1
+          collectionFormat: csv
+          uniqueItems: true
+        - description: An optional client id to filter on. This is not the primary key.
+          in: query
+          name: client_token_id
+          required: false
+          type: string
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: ''
+          headers:
+            X-Total-Count:
+              type: integer
+              description: The total number of results matching the query
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/client'
+
+      tags:
+        - authentication
+
+  /clients/{client_id}:
+    parameters:
+      - $ref: '#/parameters/optional_portal_context_header'
+      - $ref: '#/parameters/client_id'
+    get:
+      operationId: client_read
+      x-aor-permissions:
+        - 'urn:ge:identity_provider:oidc_provider:client:read'
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/client'
+      tags:
+        - authentication
+
+  /countries:
+    parameters:
+      - $ref: '#/parameters/optional_portal_context_header'
+    get:
+      operationId: country_list
+      parameters:
+        - $ref: '#/parameters/optional_offset'
+        - $ref: '#/parameters/optional_limit'
+        - name: country_codes
+          description: An optional list of country codes
+          in: query
+          type: array
+          items:
+            type: string
+            minLength: 2
+            maxLength: 2
+          required: false
+          minItems: 1
+          collectionFormat: csv
+          uniqueItems: true
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: ''
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/country'
+          headers:
+            X-Total-Count:
+              type: integer
+              description: The total number of results matching the query
+
+      tags:
+        - authentication
+
+  /countries/{country_code}:
+    parameters:
+      - $ref: '#/parameters/optional_portal_context_header'
+      - $ref: '#/parameters/country_code'
+    get:
+      operationId: country_read
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/country'
+      tags:
+        - authentication
+
+  /invitations/{invitation_id}/send:
+    parameters:
+      - name: invitation_id
+        type: string
+        format: uuid
+        in: path
+        required: true
+      - name: language
+        type: string
+        in: query
+        required: false
+        default: "en"
+    get:
+      operationId: invitation_send
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: 'An invitation email was successfully queued for sending.'
+      tags:
+        - authentication
+
+  /invitations/purge/expired:
+    get:
+      operationId: purge_expired_invitations
+      parameters:
+        - $ref: '#/parameters/synchronous_mode'
+        - $ref: '#/parameters/optional_cutoff_date'
+      produces:
+        - application/json
+      responses:
+        200:
+          description: 'Expired Invitations Purged'
+          schema:
+            $ref: '#/definitions/purged_invitations'
+        403:
+          description: 'Forbidden'
+      tags:
+        - operational
+
+  /request_user_deletion:
+    post:
+      operationId: request_user_deletion
+      consumes:
+        - application/json
+      parameters:
+        - in: body
+          name: data
+          schema:
+            $ref: '#/definitions/request_user_deletion'
+          required: true
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: ''
+      tags:
+        - authentication
+
+  /organisations:
+    parameters:
+      - $ref: '#/parameters/optional_portal_context_header'
+    get:
+      operationId: organisation_list
+      x-aor-permissions:
+        - 'urn:ge:identity_provider:organisation:read'
+      parameters:
+        - $ref: '#/parameters/optional_offset'
+        - $ref: '#/parameters/optional_limit'
+        - name: organisation_ids
+          description: An optional list of organisation ids
+          in: query
+          type: array
+          items:
+            type: integer
+          required: false
+          minItems: 1
+          collectionFormat: csv
+          uniqueItems: true
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: ''
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/organisation'
+          headers:
+            X-Total-Count:
+              type: integer
+              description: The total number of results matching the query
+      tags:
+        - authentication
+    post:
+      consumes:
+        - application/json
+      operationId: organisation_create
+      x-aor-permissions:
+        - 'urn:ge:identity_provider:organisation:create'
+      parameters:
+        - in: body
+          name: data
+          schema:
+            $ref: '#/definitions/organisation_create'
+      produces:
+        - application/json
+      responses:
+        '201':
+          description: ''
+          schema:
+            $ref: '#/definitions/organisation'
+      tags:
+        - authentication
+
+  /organisations/{organisation_id}:
+    parameters:
+      - $ref: '#/parameters/optional_portal_context_header'
+      - $ref: '#/parameters/organisation_id'
+    delete:
+      operationId: organisation_delete
+      x-aor-permissions:
+        - 'urn:ge:identity_provider:organisation:delete'
+      responses:
+        '204':
+          description: ''
+      tags:
+        - authentication
+    get:
+      operationId: organisation_read
+      x-aor-permissions:
+        - 'urn:ge:identity_provider:organisation:read'
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/organisation'
+      tags:
+        - authentication
+    put:
+      consumes:
+        - application/json
+      operationId: organisation_update
+      x-aor-permissions:
+        - 'urn:ge:identity_provider:organisation:update'
+      parameters:
+        - in: body
+          name: data
+          schema:
+            $ref: '#/definitions/organisation_update'
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/organisation'
+      tags:
+        - authentication
+
+  /users:
+    parameters:
+      - $ref: '#/parameters/optional_portal_context_header'
+    get:
+      operationId: user_list
+      x-aor-permissions:
+        - 'urn:ge:identity_provider:user:read'
+      parameters:
+        - $ref: '#/parameters/optional_offset'
+        - $ref: '#/parameters/optional_limit'
+        - name: birth_date
+          description: An optional birth_date range filter
+          in: query
+          required: false
+          type: string
+          x-aor-filter:
+            format: date
+            range: true
+        - name: country
+          description: An optional country filter
+          in: query
+          required: false
+          type: string
+          minLength: 2
+          maxLength: 2
+          x-related-info:
+            rest_resource_name: countries
+            label: name
+        - name: date_joined
+          description: An optional date joined range filter
+          in: query
+          required: false
+          type: string
+          x-aor-filter:
+            format: date
+            range: true
+        - name: email
+          description: An optional case insensitive email inner match filter
+          in: query
+          required: false
+          type: string
+          minLength: 3
+        - name: email_verified
+          description: An optional email verified filter
+          in: query
+          required: false
+          type: boolean
+        - name: first_name
+          description: An optional case insensitive first name inner match filter
+          in: query
+          required: false
+          type: string
+          minLength: 3
+        - name: gender
+          description: An optional gender filter
+          in: query
+          required: false
+          type: string
+        - name: is_active
+          description: An optional is_active filter
+          in: query
+          required: false
+          type: boolean
+        - name: last_login
+          description: An optional last login range filter
+          in: query
+          required: false
+          type: string
+          x-aor-filter:
+            format: date
+            range: true
+        - name: last_name
+          description: An optional case insensitive last name inner match filter
+          in: query
+          required: false
+          type: string
+          minLength: 3
+        - name: msisdn
+          description: An optional case insensitive MSISDN inner match filter
+          in: query
+          required: false
+          type: string
+          minLength: 3
+        - name: msisdn_verified
+          description: An optional MSISDN verified filter
+          in: query
+          required: false
+          type: boolean
+        - name: nickname
+          description: An optional case insensitive nickname inner match filter
+          in: query
+          required: false
+          type: string
+          minLength: 3
+        - name: organisation_id
+          description: An optional filter on the organisation id
+          in: query
+          required: false
+          type: integer
+        - name: updated_at
+          description: An optional updated_at range filter
+          in: query
+          required: false
+          type: string
+          x-aor-filter:
+            format: date-time
+            range: true
+        - name: username
+          description: An optional case insensitive username inner match filter
+          in: query
+          required: false
+          type: string
+          minLength: 3
+        - name: q
+          description: An optional case insensitive inner match filter across all searchable text fields
+          in: query
+          required: false
+          type: string
+          minLength: 3
+        - name: tfa_enabled
+          description: An optional filter based on whether a user has 2FA enabled or not
+          in: query
+          required: false
+          type: boolean
+        - name: has_organisation
+          description: An optional filter based on whether a user belongs to an organisation or not
+          in: query
+          required: false
+          type: boolean
+        - name: order_by
+          description: Fields and directions to order by, e.g. "-created_at,username". Add "-" in front
+            of a field name to indicate descending order.
+          in: query
+          required: false
+          type: array
+          collectionFormat: csv
+          items:
+            type: string
+          uniqueItems: true
+        - name: user_ids
+          description: An optional list of user ids
+          in: query
+          type: array
+          items:
+            type: string
+            format: uuid
+          required: false
+          minItems: 1
+          collectionFormat: csv
+          uniqueItems: true
+        - name: site_ids
+          description: An optional list of site ids
+          in: query
+          type: array
+          items:
+            type: integer
+          required: false
+          minItems: 1
+          collectionFormat: csv
+          uniqueItems: true
+          x-related-info:
+            rest_resource_name: sites
+            label: name
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: ''
+          headers:
+            X-Total-Count:
+              type: integer
+              description: The total number of results matching the query
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/user'
+      tags:
+        - authentication
+
+  '/users/{user_id}':
+    parameters:
+      - $ref: '#/parameters/optional_portal_context_header'
+      - $ref: '#/parameters/user_id'
+    delete:
+      operationId: user_delete
+      x-aor-permissions:
+        - 'urn:ge:identity_provider:user:delete'
+      responses:
+        '204':
+          description: ''
+      tags:
+        - authentication
+    get:
+      operationId: user_read
+      x-aor-permissions:
+        - 'urn:ge:identity_provider:user:read'
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/user'
+      tags:
+        - authentication
+
+    put:
+      consumes:
+        - application/json
+      operationId: user_update
+      x-aor-permissions:
+        - 'urn:ge:identity_provider:user:update'
+      parameters:
+        - in: body
+          name: data
+          schema:
+            $ref: '#/definitions/user_update'
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: ''
+          schema:
+            $ref: '#/definitions/user'
+      tags:
+        - authentication
+
+x-detail-page-definitions:
+  domain:
+    inlines:
+    - model: domain
+      label: Child Domains
+      key: parent_id
+      fields:
+        - id
+        - name
+        - created_at
+        - updated_at
+    - model: domain_role
+      label: Roles
+      key: domain_id
+      fields:
+        - role_id
+        - created_at
+        - updated_at
+#    sortable_fields:
+#      - id
+#  domainrole:
+#    sortable_fields:
+#      - domain_id
+#      - role_id
+  invitation:
+    inlines:
+    - model: invitation_domain_role
+      label: Domain Roles
+      key: invitation_id
+      fields:
+        - domain_id
+        - role_id
+        - created_at
+        - updated_at
+    - model: invitation_site_role
+      label: Site Roles
+      key: invitation_id
+      fields:
+        - site_id
+        - role_id
+        - created_at
+        - updated_at
+#    sortable_fields:
+#      - id
+#  invitationdomainrole:
+#    sortable_fields:
+#      - invitation_id
+#      - domain_id
+#      - role_id
+#  invitationsiterole:
+#    sortable_fields:
+#      - invitation_id
+#      - site_id
+#      - role_id
+#  permission:
+#    sortable_fields:
+#      - id
+#  resource:
+#    sortable_fields:
+#      - id
+  role:
+    inlines:
+    - model: role_resource_permission
+      label: Resource Permissions
+      key: role_id
+      fields:
+        - resource_id
+        - permission_id
+        - created_at
+        - updated_at
+#    sortable_fields:
+#      - id
+#  roleresourcepermission:
+#    sortable_fields:
+#      - id
+  site:
+    inlines:
+    - model: site_role
+      label: Roles
+      key: site_id
+      fields:
+        - role_id
+        - created_at
+        - updated_at
+#    sortable_fields:
+#      - id
+#  siteroles:
+#    sortable_fields:
+#      - site_id
+#      - role_id
+#  userdomainrole:
+#    sortable_fields:
+#      - user_id
+#      - domain_id
+#      - role_id
+#  usersiterole:
+#    sortable_fields:
+#      - user_id
+#      - domain_id
+#      - role_id
+#  usersitedata:
+#    sortable_fields:
+#      - user_id
+#      - site_id
+#  adminnote:
+#    sortable_fields:
+#      - id
+#  sitedataschema:
+#    sortable_fields:
+#      - site_id
+#  client:
+#    sortable_fields:
+#      - id
+#      - client_id
+#  country:
+#    sortable_fields:
+#      - code
+#  organisation:
+#    sortable_fields:
+#      - id
+  user:
+    inlines:
+    - model: user_domain_role
+      label: Domain Roles
+      key: user_id
+      fields:
+        - domain_id
+        - role_id
+        - created_at
+        - updated_at
+    - model: user_site_data
+      rest_resource_name: usersitedata
+      label: Site Data
+      key: user_id
+      fields:
+        - site_id
+        - data
+        - created_at
+        - updated_at
+    - model: user_site_role
+      label: Site Roles
+      key: user_id
+      fields:
+        - site_id
+        - role_id
+        - created_at
+        - updated_at
+    sortable_fields:
+      - id
+  deleteduser:
+    inlines:
+    - model: deleted_user_site
+      label: Sites which the user visited
+      key: deleted_user_id
+      fields:
+      - site_id
+      - deletion_requested_at
+      - deletion_requested_via
+      - deletion_confirmed_at
+      - deletion_confirmed_via
+      - created_at
+      - updated_at
+

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -37,6 +37,8 @@ ALL_TEST_SPECIFICATIONS = [
     # "tests/resources/v1beta3.json",
     # "tests/resources/wordnik.json",
     # "tests/resources/wordnik.yaml",
+    "tests/resources/management_layer.yml",
+    "tests/resources/authentication_service.yml"
 ]
 
 


### PR DESCRIPTION
# What was done
1. `jsonschema` did not validate `format` specifiers, now it does.
2. For some types, validation was not performed on extra fields, like "enum", etc. This should be covered now.
3. Use Jinja filters where possible in order to make the templates (slightly) simpler.